### PR TITLE
Fixed building on nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ lto = false
 debug-assertions = false
 codegen-units = 1
 
-[profile.debug]
+[profile.dev]
 panic = "unwind"
 
 [profile.release]


### PR DESCRIPTION
Hey :wave:!

https://github.com/rust-lang/cargo/pull/6989 added experimental support for defining custom named profiles in `Cargo.toml` but since we were using a profile named `debug`, which has been renamed to `dev` for some time apparently, cargo decided to throw errors instead of ignoring it and showing warnings.