### PR TITLE
Disallowing access to the system's supervisor

### DIFF
--- a/bastion/src/bastion.rs
+++ b/bastion/src/bastion.rs
@@ -217,12 +217,15 @@ impl Bastion {
     }
 
     /// Creates a new [`Children`], passes it through the specified
-    /// `init` closure and then sends it to the system's default
-    /// supervisor for it to start supervising it.
+    /// `init` closure and then sends it to the system supervisor
+    /// for it to start supervising it.
     ///
     /// This methods returns a [`ChildrenRef`] referencing the newly
     /// created children group it it succeeded, or `Err(())`
     /// otherwise.
+    ///
+    /// Note that the "system supervisor" is a supervisor created
+    /// by the system at startup.
     ///
     /// # Arguments
     ///

--- a/bastion/src/children.rs
+++ b/bastion/src/children.rs
@@ -403,8 +403,7 @@ impl Children {
 
             let child_ref = ChildRef::new(id.clone(), sender.clone());
             let children = self.as_ref();
-            // FIXME
-            let supervisor = self.bcast.parent().clone().into_supervisor().unwrap();
+            let supervisor = self.bcast.parent().clone().into_supervisor();
 
             let state = ContextState::new();
             let state = Qutex::new(state);

--- a/bastion/src/context.rs
+++ b/bastion/src/context.rs
@@ -120,8 +120,8 @@ impl BastionContext {
 
     /// Returns a [`SupervisorRef`] referencing the supervisor
     /// that supervises the element that is linked to this
-    /// `BastionContext` if it isn't the system's supervisor
-    /// (if the children group wasn't created using
+    /// `BastionContext` if it isn't the system supervisor
+    /// (ie. if the children group wasn't created using
     /// [`Bastion::children`]).
     ///
     /// # Example

--- a/bastion/src/context.rs
+++ b/bastion/src/context.rs
@@ -16,7 +16,7 @@ pub struct BastionContext {
     id: BastionId,
     child: ChildRef,
     children: ChildrenRef,
-    supervisor: SupervisorRef,
+    supervisor: Option<SupervisorRef>,
     state: Qutex<ContextState>,
 }
 
@@ -38,7 +38,7 @@ impl BastionContext {
         id: BastionId,
         child: ChildRef,
         children: ChildrenRef,
-        supervisor: SupervisorRef,
+        supervisor: Option<SupervisorRef>,
         state: Qutex<ContextState>,
     ) -> Self {
         BastionContext {
@@ -172,11 +172,7 @@ impl BastionContext {
     /// [`SupervisorRef`]: supervisor/struct.SupervisorRef.html
     /// [`Bastion::children`]: struct.Bastion.html#method.children
     pub fn supervisor(&self) -> Option<&SupervisorRef> {
-        if self.supervisor.is_system_supervisor() {
-            None
-        } else {
-            Some(&self.supervisor)
-        }
+        self.supervisor.as_ref()
     }
 
     /// Tries to retrieve asynchronously a message received by

--- a/bastion/src/supervisor.rs
+++ b/bastion/src/supervisor.rs
@@ -76,10 +76,6 @@ pub struct Supervisor {
 pub struct SupervisorRef {
     id: BastionId,
     sender: Sender,
-    // Whether the supervisor referenced was started by
-    // the system (in which case, users shouldn't be able
-    // to get a reference to it).
-    is_system_supervisor: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -195,9 +191,8 @@ impl Supervisor {
         // TODO: clone or ref?
         let id = self.bcast.id().clone();
         let sender = self.bcast.sender().clone();
-        let is_system_supervisor = self.is_system_supervisor;
 
-        SupervisorRef::new(id, sender, is_system_supervisor)
+        SupervisorRef::new(id, sender)
     }
 
     /// Creates a new supervisor, passes it through the specified
@@ -764,11 +759,10 @@ impl Supervisor {
 }
 
 impl SupervisorRef {
-    pub(crate) fn new(id: BastionId, sender: Sender, is_system_supervisor: bool) -> Self {
+    pub(crate) fn new(id: BastionId, sender: Sender) -> Self {
         SupervisorRef {
             id,
             sender,
-            is_system_supervisor,
         }
     }
 
@@ -1052,10 +1046,6 @@ impl SupervisorRef {
     pub fn kill(&self) -> Result<(), ()> {
         let msg = BastionMessage::kill();
         self.send(msg).map_err(|_| ())
-    }
-
-    pub(crate) fn is_system_supervisor(&self) -> bool {
-        self.is_system_supervisor
     }
 
     pub(crate) fn send(&self, msg: BastionMessage) -> Result<(), BastionMessage> {

--- a/bastion/src/supervisor.rs
+++ b/bastion/src/supervisor.rs
@@ -760,10 +760,7 @@ impl Supervisor {
 
 impl SupervisorRef {
     pub(crate) fn new(id: BastionId, sender: Sender) -> Self {
-        SupervisorRef {
-            id,
-            sender,
-        }
+        SupervisorRef { id, sender }
     }
 
     /// Creates a new [`Supervisor`], passes it through the specified

--- a/bastion/src/supervisor.rs
+++ b/bastion/src/supervisor.rs
@@ -57,7 +57,9 @@ pub struct Supervisor {
     // supervision strategy is not "one-for-one".
     stopped: FxHashMap<BastionId, Supervised>,
     strategy: SupervisionStrategy,
-    // TODO: doc
+    // Whether this supervisor was started by the system (in
+    // which case, users shouldn't be able to get a reference
+    // to it).
     is_system_supervisor: bool,
     // Messages that were received before the supervisor was
     // started. Those will be "replayed" once a start message
@@ -74,7 +76,9 @@ pub struct Supervisor {
 pub struct SupervisorRef {
     id: BastionId,
     sender: Sender,
-    // TODO: doc
+    // Whether the supervisor referenced was started by
+    // the system (in which case, users shouldn't be able
+    // to get a reference to it).
     is_system_supervisor: bool,
 }
 

--- a/bastion/src/supervisor.rs
+++ b/bastion/src/supervisor.rs
@@ -22,6 +22,10 @@ use std::task::Poll;
 /// supervisor will restart it and eventually some of its other
 /// supervised entities, depending on its supervision strategy.
 ///
+/// Note that a supervisor, called the "system supervisor", is
+/// created by the system at startup and is the supervisor
+/// supervising children groups created via [`Bastion::children`].
+///
 /// # Example
 ///
 /// ```
@@ -45,6 +49,7 @@ use std::task::Poll;
 /// [`Children`]: children/struct.Children.html
 /// [`SupervisionStrategy`]: supervisor/enum.SupervisionStrategy.html
 /// [`with_strategy`]: #method.with_strategy
+/// [`Bastion::children`]: struct.Bastion.html#method.children
 pub struct Supervisor {
     bcast: Broadcast,
     // The order in which children and supervisors were added.

--- a/bastion/src/system.rs
+++ b/bastion/src/system.rs
@@ -53,7 +53,7 @@ impl System {
         let parent = Parent::system();
         let bcast = Broadcast::with_id(parent, NIL_ID);
 
-        let supervisor = Supervisor::new(bcast);
+        let supervisor = Supervisor::system(bcast);
         let supervisor_ref = supervisor.as_ref();
 
         let msg = BastionMessage::deploy_supervisor(supervisor);


### PR DESCRIPTION
- [x] Update `Context::supervisor` to return `None` when the supervisor is the system's.
- [x] Add documentation for `Supervisor.is_system_supervisor` and `SupervisorRef.is_system_supervisor`.
- [x] Decide whether to put `Context.supervisor` inside an `Option` and not store a `SupervisorRef` referencing the system's supervisor.
- [x] Create an issue for the children group elems being launched before the group itself.
- [x] Add information about the system's supervisor (in `Bastion::init` maybe; saying that it is just a supervisor that is created by the system and used to supervise children groups when using `Bastion::children`).