### PR TITLE
Moved ROOT_SPV out of its QrwLock

### DIFF
--- a/bastion/src/bastion.rs
+++ b/bastion/src/bastion.rs
@@ -2,7 +2,7 @@ use crate::broadcast::{Broadcast, Parent};
 use crate::children::{Children, ChildrenRef};
 use crate::message::{BastionMessage, Message};
 use crate::supervisor::{Supervisor, SupervisorRef};
-use crate::system::{ROOT_SPV, SYSTEM, SYSTEM_SENDER};
+use crate::system::{System, SYSTEM, SYSTEM_SENDER};
 use std::fmt::{self, Debug, Formatter};
 use std::thread;
 
@@ -266,7 +266,7 @@ impl Bastion {
         C: FnOnce(Children) -> Children,
     {
         // FIXME: unsafe?
-        if let Some(supervisor) = unsafe { &ROOT_SPV } {
+        if let Some(supervisor) = System::root_supervisor() {
             supervisor.children(init)
         } else {
             // TODO: Err(Error)

--- a/bastion/src/bastion.rs
+++ b/bastion/src/bastion.rs
@@ -265,15 +265,13 @@ impl Bastion {
     where
         C: FnOnce(Children) -> Children,
     {
-        // FIXME: panics
-        ROOT_SPV
-            .clone()
-            .read()
-            .wait()
-            .unwrap()
-            .as_ref()
-            .unwrap()
-            .children(init)
+        // FIXME: unsafe?
+        if let Some(supervisor) = unsafe { &ROOT_SPV } {
+            supervisor.children(init)
+        } else {
+            // TODO: Err(Error)
+            Err(())
+        }
     }
 
     /// Sends a message to the system which will then send it to all

--- a/bastion/src/supervisor.rs
+++ b/bastion/src/supervisor.rs
@@ -132,11 +132,16 @@ impl Supervisor {
         ProcStack::default()
     }
 
-    pub(crate) async fn reset(&mut self, bcast: Broadcast) {
+    pub(crate) async fn reset(&mut self, bcast: Option<Broadcast>) {
         // TODO: stop or kill?
         let killed = self.kill(0..).await;
 
-        self.bcast = bcast;
+        if let Some(bcast) = bcast {
+            self.bcast = bcast;
+        } else {
+            self.bcast.clear_children();
+        }
+
         self.pre_start_msgs.clear();
         self.pre_start_msgs.shrink_to_fit();
 
@@ -1067,7 +1072,7 @@ impl Supervised {
                 let stack = ProcStack::default();
                 pool::spawn(
                     async {
-                        supervisor.reset(bcast).await;
+                        supervisor.reset(Some(bcast)).await;
                         Supervised::Supervisor(supervisor)
                     },
                     stack,

--- a/bastion/src/system.rs
+++ b/bastion/src/system.rs
@@ -13,7 +13,7 @@ use qutex::Qutex;
 use std::cell::RefCell;
 use std::task::Poll;
 
-pub(crate) static mut ROOT_SPV: Option<SupervisorRef> = None;
+static mut ROOT_SPV: Option<SupervisorRef> = None;
 
 lazy_static! {
     pub(crate) static ref SYSTEM: Qutex<Option<RecoverableHandle<()>>> = Qutex::new(None);
@@ -73,6 +73,10 @@ impl System {
         unsafe { ROOT_SPV = Some(supervisor_ref) };
 
         sender
+    }
+
+    pub(crate) fn root_supervisor() -> Option<&'static SupervisorRef> {
+        unsafe { ROOT_SPV.as_ref() }
     }
 
     // TODO: set a limit?

--- a/bastion/src/system.rs
+++ b/bastion/src/system.rs
@@ -83,16 +83,15 @@ impl System {
     async fn recover(&mut self, mut supervisor: Supervisor) {
         let parent = Parent::system();
         let bcast = if supervisor.id() == &NIL_ID {
-            Broadcast::with_id(parent, NIL_ID)
+            None
         } else {
-            Broadcast::new(parent)
+            Some(Broadcast::new(parent))
         };
-
-        let id = bcast.id().clone();
 
         supervisor.reset(bcast).await;
         self.bcast.register(supervisor.bcast());
 
+        let id = supervisor.id().clone();
         let launched = supervisor.launch();
         self.launched.insert(id, launched);
     }


### PR DESCRIPTION
Hey :wave:!

I moved `ROOT_SPV` (used by `Bastion::children`) out of `lazy_static!` and a `QrwLock`into a `static mut` (I know...). This should be better for when creating new "root-level" children (both performance and contention-wise) but added two `unsafe` blocks to the code.

`ROOT_SPV` is guaranteed to only be written to once (in `System::init`, called inside a `lazy_static!`; and it can't be accessed from outside `system.rs`).

I also fixed a bug making `ROOT_SPV` pointing to a restarted `Supervisor` (thus, with a different `Sender`).