### PR TITLE
[executor] Fetch cores at once, rely on runtime

### DIFF
--- a/bastion-executor/src/load_balancer.rs
+++ b/bastion-executor/src/load_balancer.rs
@@ -31,7 +31,7 @@ impl LoadBalancer {
                             .smp_queues
                             .values()
                             .sum::<usize>()
-                            .wrapping_div(placement::get_core_ids().unwrap().len());
+                            .wrapping_div(*core_retrieval());
                     }
 
                     // Try sleeping for a while to wait
@@ -84,4 +84,15 @@ pub fn stats() -> &'static ShardedLock<Stats> {
         };
     }
     &*LB_STATS
+}
+
+///
+/// Retrieve core count for the runtime scheduling purposes
+#[inline]
+pub fn core_retrieval() -> &'static usize {
+    lazy_static! {
+        static ref CORE_COUNT: usize = { placement::get_core_ids().unwrap().len() };
+    }
+
+    &*CORE_COUNT
 }

--- a/bastion/src/broadcast.rs
+++ b/bastion/src/broadcast.rs
@@ -132,7 +132,7 @@ impl Broadcast {
     }
 
     pub(crate) fn send_children(&self, msg: BastionMessage) {
-        for (_, child) in &self.children {
+        for child in self.children.values() {
             // FIXME: Err(Error) if None
             if let Some(msg) = msg.try_clone() {
                 // FIXME: handle errors


### PR DESCRIPTION
This fetches cores once at the runtime and replaces our continuous fetch of topology.
Possible fix for: #109 