### PR TITLE
Ignore migration path under lock contention

### DIFF
--- a/bastion-executor/src/load_balancer.rs
+++ b/bastion-executor/src/load_balancer.rs
@@ -19,8 +19,8 @@ pub struct LoadBalancer;
 
 impl LoadBalancer {
     ///
-    /// Statistics sampling thread for run queue load balancing.
-    pub fn sample() {
+    /// AMQL sampling thread for run queue load balancing.
+    pub fn amql_generation() {
         thread::Builder::new()
             .name("load-balancer-thread".to_string())
             .spawn(move || {
@@ -34,8 +34,11 @@ impl LoadBalancer {
                             .wrapping_div(*core_retrieval());
                     }
 
+                    // We don't have β-reduction here… Life is unfair. Life is cruel.
+                    //
                     // Try sleeping for a while to wait
-                    thread::sleep(Duration::new(0, 10));
+                    // Should be smaller time slice than 4 times per second to not miss
+                    thread::sleep(Duration::from_millis(245));
                     // Yield immediately back to os so we can advance in workers
                     thread::yield_now();
                 }
@@ -76,8 +79,8 @@ pub fn stats() -> &'static ShardedLock<Stats> {
                 )
             };
 
-            // Start sampler
-            LoadBalancer::sample();
+            // Start AMQL generator
+            LoadBalancer::amql_generation();
 
             // Return stats
             ShardedLock::new(stats)

--- a/bastion-executor/src/worker.rs
+++ b/bastion-executor/src/worker.rs
@@ -130,6 +130,7 @@ fn affine_steal(pool: &Pool, local: &Worker<LightProc>, affinity: usize) -> Opti
                                                 .get(s.0)
                                                 .unwrap()
                                                 .steal_batch_and_pop(&local)
+                                            // TODO: Set evacuation flag in thread_local
                                         }
                                     })
                                     .collect()
@@ -139,7 +140,7 @@ fn affine_steal(pool: &Pool, local: &Worker<LightProc>, affinity: usize) -> Opti
                     }
                 })
             }
-            Err(_) => Steal::Retry,
+            Err(_) => Steal::Empty, // Behave like there is no job under the contention.
         })
         // Loop while no task was stolen and any steal operation needs to be retried.
         .find(|s| !s.is_retry())

--- a/bastion/tests/prop_children_broadcast.rs
+++ b/bastion/tests/prop_children_broadcast.rs
@@ -18,7 +18,7 @@ proptest! {
                 .with_exec(move |ctx: BastionContext| {
                     async move {
                         msg! { ctx.recv().await?,
-                            ref msg: &'static str => {
+                            ref _msg: &'static str => {
                                 ;
                             };
                             // This won't happen because this example

--- a/bastion/tests/prop_children_message.rs
+++ b/bastion/tests/prop_children_message.rs
@@ -35,7 +35,7 @@ proptest! {
                         }
 
                         msg! { answer.await?,
-                            msg: &'static str => {
+                            _msg: &'static str => {
                                 ;
                             };
                             _: _ => ();


### PR DESCRIPTION
Job migrators will defer queue migration under the lock contention. Fixes #109 .