### PR TITLE
Replaced "futures-preview" with "futures"

### DIFF
--- a/bastion/Cargo.toml
+++ b/bastion/Cargo.toml
@@ -36,7 +36,7 @@ unstable = ["bastion-executor/unstable"]
 
 [dependencies]
 bastion-executor = { version = "= 0.3.1", path = "../bastion-executor" }
-futures-preview = { version = "=0.3.0-alpha.19", features = ["async-await"] }
+futures = { version = "0.3", features = ["async-await"] }
 fxhash = "0.2"
 lazy_static = "1.4"
 lightproc = { version = "= 0.3.3", path = "../lightproc" }


### PR DESCRIPTION
Hey :wave:!

I replaced `futures-preview = "=0.3.0-alpha.19"` with `futures = "0.3"` in `bastion`'s `Cargo.toml` :)