### PR TITLE
Fix link and remove empty doc

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ the requirements below.
 
 Bug fixes and new features should include tests and possibly benchmarks.
 
-Contributors guide: https://github.com/bastion-rs/bastion/blob/master/CONTRIBUTING.md
+Contributors guide: https://github.com/bastion-rs/.github/blob/master/CONTRIBUTING.md
 -->
 
 ##### Checklist

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ More interaction and more ideas are better!
 
 All contributions, bug reports, bug fixes, documentation improvements, enhancements and ideas are welcome.
 
-A detailed overview on how to contribute can be found in the  [CONTRIBUTING guide](.github/CONTRIBUTING.md) on GitHub.
+A detailed overview on how to contribute can be found in the  [CONTRIBUTING guide](https://github.com/bastion-rs/.github/blob/master/CONTRIBUTING.md) on GitHub.
 
 ---
 <sup><sub>* Currently, we are working on distributed properties and protocol[.](https://spoti.fi/2OaEsj9)</sub></sup>


### PR DESCRIPTION
Fix contributing guide link and remove empty support documentation (it already exists on `.github` repo).
Fixes #123

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are passing with `cargo test`. 
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message is clear
