### PR TITLE
Bump bastion-executor dependency to 0.3.2-alpha.0

### DIFF
--- a/bastion/Cargo.toml
+++ b/bastion/Cargo.toml
@@ -35,7 +35,7 @@ maintenance = { status = "actively-developed" }
 unstable = ["bastion-executor/unstable"]
 
 [dependencies]
-bastion-executor = { version = "= 0.3.1", path = "../bastion-executor" }
+bastion-executor = { version = "= 0.3.2-alpha.0", path = "../bastion-executor" }
 futures = { version = "0.3", features = ["async-await"] }
 fxhash = "0.2"
 lazy_static = "1.4"


### PR DESCRIPTION
Fix failing build. Bump dependency to new bastion-executor version introduced in 71b9649

##### Checklist
- [x] tests are passing with `cargo test`
- [x] commit message is clear

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
