### PR TITLE
Max retries support for existing restart strategies

### DIFF
--- a/bastion/examples/restart_strategy.rs
+++ b/bastion/examples/restart_strategy.rs
@@ -24,7 +24,7 @@ fn supervisor(supervisor: Supervisor) -> Supervisor {
 }
 
 fn failed_actors_group(children: Children) -> Children {
-    children.with_exec(move |ctx: BastionContext| async move {
+    children.with_exec(move |_ctx: BastionContext| async move {
         println!("Worker started!");
         panic!("Unexpected error...");
     })

--- a/bastion/examples/restart_strategy.rs
+++ b/bastion/examples/restart_strategy.rs
@@ -1,0 +1,31 @@
+use std::time::Duration;
+
+use bastion::prelude::*;
+
+fn main() {
+    Bastion::init();
+
+    Bastion::supervisor(supervisor).expect("Couldn't create the supervisor.");
+
+    Bastion::start();
+    Bastion::block_until_stopped();
+}
+
+fn supervisor(supervisor: Supervisor) -> Supervisor {
+    let restart_strategy = RestartStrategy::default()
+        .with_max_restarts(Some(3))
+        .with_actor_restart_strategy(ActorRestartStrategy::LinearBackOff {
+            timeout: Duration::from_secs(1),
+        });
+
+    supervisor
+        .with_restart_strategy(restart_strategy)
+        .children(|children| failed_actors_group(children))
+}
+
+fn failed_actors_group(children: Children) -> Children {
+    children.with_exec(move |ctx: BastionContext| async move {
+        println!("Worker started!");
+        panic!("Unexpected error...");
+    })
+}

--- a/bastion/examples/restart_strategy.rs
+++ b/bastion/examples/restart_strategy.rs
@@ -20,7 +20,6 @@ fn main() {
     Bastion::block_until_stopped();
 }
 
-
 fn supervisor(supervisor: Supervisor) -> Supervisor {
     // Here we are specifying the used restart strategy for our supervisor.
     // By default the bastion's supervisors are always trying to restart

--- a/bastion/examples/restart_strategy.rs
+++ b/bastion/examples/restart_strategy.rs
@@ -2,6 +2,15 @@ use std::time::Duration;
 
 use bastion::prelude::*;
 
+///
+/// Supervisors with a custom restart strategy example.
+///
+/// Prologue:
+/// This examples demonstrates how to override the default restart strategy
+/// on a custom, provided by the bastion crate. The supervisor will spawn
+/// the only one tracked actor that will be restarted a couple of times and
+/// the certain timeout after a raised failure in the actor's code.
+///
 fn main() {
     Bastion::init();
 
@@ -11,19 +20,40 @@ fn main() {
     Bastion::block_until_stopped();
 }
 
+
 fn supervisor(supervisor: Supervisor) -> Supervisor {
+    // Here we are specifying the used restart strategy for our supervisor.
+    // By default the bastion's supervisors are always trying to restart
+    // failed actors with unlimited amount of tries.
+    //
+    // At the beginning we're creating a new instance of RestartStrategy
+    // and then provides a policy and a back-off strategy.
     let restart_strategy = RestartStrategy::default()
-        .with_max_restarts(Some(3))
+        // Set the limits for supervisor, so that it could stop
+        // after 3 attempts. If the actor can't be started, the supervisor
+        // will remove the failed actor from tracking.
+        .with_restart_policy(RestartPolicy::Tries(3))
+        // Set the desired restart strategy. By default supervisor will
+        // try to restore the failed actor as soon as possible. However,
+        // in our case we want to restart with a small delay between the
+        // tries. Let's say that we want a regular time interval between the
+        // attempts which is equal to 1 second.
         .with_actor_restart_strategy(ActorRestartStrategy::LinearBackOff {
             timeout: Duration::from_secs(1),
         });
 
+    // After it we define the supervisor...
     supervisor
+        // That uses our restart strategy defined earlier
         .with_restart_strategy(restart_strategy)
+        // And tracks the child group, defined in the following function
         .children(|children| failed_actors_group(children))
 }
 
 fn failed_actors_group(children: Children) -> Children {
+    // Specifying the child group, where each actor
+    // will output the sentence in the stdout, then will fail
+    // with panic.
     children.with_exec(move |_ctx: BastionContext| async move {
         println!("Worker started!");
         panic!("Unexpected error...");

--- a/bastion/src/lib.rs
+++ b/bastion/src/lib.rs
@@ -97,7 +97,7 @@ pub mod prelude {
     pub use crate::msg;
     pub use crate::path::{BastionPath, BastionPathElement};
     pub use crate::supervisor::{
-        ActorRestartStrategy, SupervisionStrategy, Supervisor, SupervisorRef,
+        ActorRestartStrategy, RestartStrategy, SupervisionStrategy, Supervisor, SupervisorRef,
     };
     pub use crate::{blocking, children, run, spawn, supervisor};
 }

--- a/bastion/src/lib.rs
+++ b/bastion/src/lib.rs
@@ -97,7 +97,8 @@ pub mod prelude {
     pub use crate::msg;
     pub use crate::path::{BastionPath, BastionPathElement};
     pub use crate::supervisor::{
-        ActorRestartStrategy, RestartStrategy, SupervisionStrategy, Supervisor, SupervisorRef,
+        ActorRestartStrategy, RestartPolicy, RestartStrategy, SupervisionStrategy, Supervisor,
+        SupervisorRef,
     };
     pub use crate::{blocking, children, run, spawn, supervisor};
 }

--- a/bastion/src/supervisor.rs
+++ b/bastion/src/supervisor.rs
@@ -137,7 +137,7 @@ enum Supervised {
     Children(Children),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 /// The restart policy which is used during restoring failed
 /// actors by the supervisor.
 ///
@@ -159,13 +159,13 @@ pub enum RestartPolicy {
 ///
 /// The default strategy used is `ActorRestartStrategy::Immediate`
 /// with the `RestartPolicy::Always` restart policy.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct RestartStrategy {
     restart_policy: RestartPolicy,
     strategy: ActorRestartStrategy,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 /// The strategy for restating an actor as far as it
 /// returned an failure.
 ///
@@ -702,7 +702,7 @@ impl Supervisor {
     ///     # Bastion::supervisor(|sp| {
     ///     sp.with_restart_strategy(
     ///         RestartStrategy::default()
-    ///             .with_max_restarts(Some(5))     // 5 attempts
+    ///             .with_restart_policy(RestartPolicy::Tries(5))
     ///             .with_actor_restart_strategy(           
     ///                 ActorRestartStrategy::ExponentialBackOff {
     ///                     timeout: Duration::from_millis(5000),

--- a/bastion/src/supervisor.rs
+++ b/bastion/src/supervisor.rs
@@ -18,7 +18,7 @@ use fxhash::FxHashMap;
 use lightproc::prelude::*;
 use log::Level;
 use std::cmp::{Eq, PartialEq};
-use std::ops::{Range, RangeFrom};
+use std::ops::Range;
 use std::sync::Arc;
 use std::task::Poll;
 use std::time::Duration;
@@ -851,7 +851,7 @@ impl Supervisor {
         }
     }
 
-    async fn stop(&mut self, range: RangeFrom<usize>) {
+    async fn stop(&mut self, range: Range<usize>) {
         debug!("Supervisor({}): Stopping range: {:?}", self.id(), range);
         if range.start == 0 {
             self.bcast.stop_children();
@@ -982,7 +982,7 @@ impl Supervisor {
                 msg: BastionMessage::Stop,
                 ..
             } => {
-                self.stop(0..).await;
+                self.stop(0..self.order.len()).await;
                 self.stopped();
 
                 return Err(());

--- a/bastion/tests/restart_strategy.rs
+++ b/bastion/tests/restart_strategy.rs
@@ -1,0 +1,45 @@
+use bastion::supervisor::{ActorRestartStrategy, RestartPolicy, RestartStrategy};
+use std::time::Duration;
+
+#[test]
+fn check_default_values() {
+    let restart_strategy = RestartStrategy::default();
+
+    assert_eq!(restart_strategy.restart_policy(), RestartPolicy::Always);
+    assert_eq!(restart_strategy.strategy(), ActorRestartStrategy::Immediate);
+}
+
+#[test]
+fn override_restart_policy() {
+    let restart_strategy = RestartStrategy::default().with_restart_policy(RestartPolicy::Never);
+
+    assert_eq!(restart_strategy.restart_policy(), RestartPolicy::Never);
+    assert_eq!(restart_strategy.strategy(), ActorRestartStrategy::Immediate);
+}
+
+#[test]
+fn override_restart_strategy() {
+    let strategy = ActorRestartStrategy::LinearBackOff {
+        timeout: Duration::from_secs(1),
+    };
+
+    let restart_strategy = RestartStrategy::default().with_actor_restart_strategy(strategy.clone());
+
+    assert_eq!(restart_strategy.restart_policy(), RestartPolicy::Always);
+    assert_eq!(restart_strategy.strategy(), strategy);
+}
+
+#[test]
+fn override_restart_strategy_and_policy() {
+    let policy = RestartPolicy::Tries(3);
+    let strategy = ActorRestartStrategy::LinearBackOff {
+        timeout: Duration::from_secs(1),
+    };
+
+    let restart_strategy = RestartStrategy::default()
+        .with_restart_policy(policy.clone())
+        .with_actor_restart_strategy(strategy.clone());
+
+    assert_eq!(restart_strategy.restart_policy(), policy);
+    assert_eq!(restart_strategy.strategy(), strategy);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bastion-rs/.github/blob/master/CONTRIBUTING.md
-->
The following pull request contains the changes for supporting max retries for the failed actors. It covers the #105 and the #146 issues for the bastion project.

By default the restart strategy doesn't have any limits in restating the failed actor, but can be overridden via the special call (which is the `.with_max_retries`).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are passing with `cargo test`. 
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message is clear
- [x] added an example of the usage

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
