### PR TITLE
Removed Pool::recover_async_thread method

### DIFF
--- a/bastion-executor/src/pool.rs
+++ b/bastion-executor/src/pool.rs
@@ -61,12 +61,6 @@ pub struct Pool {
 }
 
 impl Pool {
-    /// Error recovery for the fallen threads
-    pub fn recover_async_thread() {
-        // FIXME: Do recovery for fallen worker threads
-        unimplemented!()
-    }
-
     ///
     /// Spawn a process (which contains future + process stack) onto the executor via [Pool] interface.
     pub fn spawn<F, T>(&self, future: F, stack: ProcStack) -> RecoverableHandle<T>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bastion-rs/.github/blob/master/CONTRIBUTING.md
-->
The following pull request drops the unused method of the bastion's pool struct, as it was discussed in the #57 issue.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are passing with `cargo test`. 
- [x] commit message is clear

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
