### PR TITLE
Move answer macro to global scope

### DIFF
--- a/bastion/src/lib.rs
+++ b/bastion/src/lib.rs
@@ -105,5 +105,5 @@ pub mod prelude {
         ActorRestartStrategy, RestartPolicy, RestartStrategy, SupervisionStrategy, Supervisor,
         SupervisorRef,
     };
-    pub use crate::{blocking, children, run, spawn, supervisor};
+    pub use crate::{blocking, children, run, spawn, supervisor, answer};
 }

--- a/bastion/src/lib.rs
+++ b/bastion/src/lib.rs
@@ -105,5 +105,5 @@ pub mod prelude {
         ActorRestartStrategy, RestartPolicy, RestartStrategy, SupervisionStrategy, Supervisor,
         SupervisorRef,
     };
-    pub use crate::{blocking, children, run, spawn, supervisor, answer};
+    pub use crate::{answer, blocking, children, run, spawn, supervisor};
 }

--- a/bastion/src/message.rs
+++ b/bastion/src/message.rs
@@ -702,6 +702,7 @@ macro_rules! msg {
 ///         # children.with_exec(move |ctx: BastionContext| {
 ///             # let child_ref = children_ref.elems()[0].clone();
 ///             # async move {
+/// // now you can ask the child, from another children
 /// let answer: Answer = ctx.ask(&child_ref.addr(), "hello").expect("Couldn't send the message.");
 ///
 /// msg! { answer.await.expect("Couldn't receive the answer."),

--- a/bastion/src/message.rs
+++ b/bastion/src/message.rs
@@ -675,3 +675,56 @@ macro_rules! msg {
         }
     } };
 }
+
+#[macro_export]
+/// Answers to a given message, with the given answer.
+///
+/// # Example
+///
+/// ```rust
+/// # use bastion::prelude::*;
+/// #
+/// # fn main() {
+///     # Bastion::init();
+///     # let children_ref =
+/// // Create a new child...
+/// Bastion::children(|children| {
+///     children.with_exec(|ctx: BastionContext| {
+///         async move {
+///             let msg = ctx.recv().await?;
+///             answer!(msg, "goodbye").unwrap();
+///             Ok(())
+///         }
+///     })
+/// }).expect("Couldn't create the children group.");
+///
+///     # Bastion::children(|children| {
+///         # children.with_exec(move |ctx: BastionContext| {
+///             # let child_ref = children_ref.elems()[0].clone();
+///             # async move {
+/// let answer: Answer = ctx.ask(&child_ref.addr(), "hello").expect("Couldn't send the message.");
+///
+/// msg! { answer.await.expect("Couldn't receive the answer."),
+///     msg: &'static str => {
+///         assert_eq!(msg, "goodbye");
+///     };
+///     _: _ => ();
+/// }
+///                 #
+///                 # Ok(())
+///             # }
+///         # })
+///     # }).unwrap();
+///     #
+///     # Bastion::start();
+///     # Bastion::stop();
+///     # Bastion::block_until_stopped();
+/// # }
+/// ```
+macro_rules! answer {
+    ($msg:expr, $answer:expr) => {{
+        let (mut msg, sign) = $msg.extract();
+        let sender = msg.take_sender().expect("failed to take render");
+        sender.send($answer, sign)
+    }};
+}


### PR DESCRIPTION
##### Checklist
- [x] tests are passing with `cargo test`. 
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message is clear

This pull request moves the `answer` macro to a global scope and re export it in the prelude module

Resolves #118 