### PR TITLE
Preserving actor's mailbox

### DIFF
--- a/bastion/src/callbacks.rs
+++ b/bastion/src/callbacks.rs
@@ -1,7 +1,16 @@
 use std::fmt::{self, Debug, Formatter};
 use std::sync::Arc;
 
-#[derive(Default)]
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub(crate) enum CallbackType {
+    AfterRestart,
+    AfterStop,
+    BeforeRestart,
+    BeforeStart,
+}
+
+#[derive(Default, Clone)]
 /// A set of methods that will get called at different states of
 /// a [`Supervisor`] or [`Children`] life.
 ///

--- a/bastion/src/child.rs
+++ b/bastion/src/child.rs
@@ -153,6 +153,10 @@ impl Child {
                 ..
             } => unimplemented!(),
             Envelope {
+                msg: BastionMessage::InstantiatedChild { .. },
+                ..
+            } => unreachable!(),
+            Envelope {
                 msg: BastionMessage::Message(msg),
                 sign,
             } => {

--- a/bastion/src/child.rs
+++ b/bastion/src/child.rs
@@ -122,9 +122,6 @@ impl Child {
         debug!("Child({}): Faulted.", self.id());
         self.remove_from_dispatchers();
 
-        // TODO: Remove these call? (we're asking here for a restart)
-        //self.bcast.faulted();
-
         let parent = self.bcast.parent().clone().into_children().unwrap();
         let path = self.bcast.path().clone();
         let sender = self.bcast.sender().clone();

--- a/bastion/src/child.rs
+++ b/bastion/src/child.rs
@@ -198,6 +198,10 @@ impl Child {
                 ..
             } => unreachable!(),
             Envelope {
+                msg: BastionMessage::FinishedChild { .. },
+                ..
+            } => unreachable!(),
+            Envelope {
                 msg: BastionMessage::DropChild { .. },
                 ..
             } => unreachable!(),

--- a/bastion/src/child.rs
+++ b/bastion/src/child.rs
@@ -92,7 +92,7 @@ impl Child {
             let id = id.clone();
             warn!("Child({}): Panicked.", id);
 
-            let msg = BastionMessage::faulted(id);
+            let msg = BastionMessage::restart_required(id, parent.id().clone());
             let env = Envelope::new(msg, path.clone(), sender.clone());
             // TODO: handle errors
             parent.send(env).ok();
@@ -165,6 +165,10 @@ impl Child {
                 let mut state = guard.as_mut();
                 state.push_message(msg, sign);
             }
+            Envelope {
+                msg: BastionMessage::RestartRequired { .. },
+                ..
+            } => unreachable!(),
             // FIXME
             Envelope {
                 msg: BastionMessage::Stopped { .. },

--- a/bastion/src/child.rs
+++ b/bastion/src/child.rs
@@ -190,6 +190,10 @@ impl Child {
                 ..
             } => unreachable!(),
             Envelope {
+                msg: BastionMessage::RestartSubtree,
+                ..
+            } => unreachable!(),
+            Envelope {
                 msg: BastionMessage::RestoreChild { .. },
                 ..
             } => unreachable!(),

--- a/bastion/src/children.rs
+++ b/bastion/src/children.rs
@@ -619,7 +619,7 @@ impl Children {
             let supervisor = self.bcast.parent().clone().into_supervisor();
 
             let state = ContextState::new();
-            let state = Qutex::new(state);
+            let state = Qutex::new(Box::pin(state));
 
             let ctx =
                 BastionContext::new(id, child_ref.clone(), children, supervisor, state.clone());

--- a/bastion/src/children.rs
+++ b/bastion/src/children.rs
@@ -579,6 +579,10 @@ impl Children {
                 ..
             } => self.request_restarting_child(&id, &parent_id),
             Envelope {
+                msg: BastionMessage::RestartSubtree,
+                ..
+            } => unreachable!(),
+            Envelope {
                 msg: BastionMessage::RestoreChild { id, state},
                 ..
             } => self.restart_child(&id, &state),

--- a/bastion/src/context.rs
+++ b/bastion/src/context.rs
@@ -13,8 +13,8 @@ use futures::pending;
 use qutex::{Guard, Qutex};
 use std::collections::VecDeque;
 use std::fmt::{self, Display, Formatter};
-use std::sync::Arc;
 use std::pin::Pin;
+use std::sync::Arc;
 use uuid::Uuid;
 
 /// Identifier for a root supervisor and dead-letters children.
@@ -587,7 +587,7 @@ impl BastionContext {
 impl ContextState {
     pub(crate) fn new() -> Self {
         ContextState {
-            messages: VecDeque::new()
+            messages: VecDeque::new(),
         }
     }
 

--- a/bastion/src/context.rs
+++ b/bastion/src/context.rs
@@ -14,6 +14,7 @@ use qutex::{Guard, Qutex};
 use std::collections::VecDeque;
 use std::fmt::{self, Display, Formatter};
 use std::sync::Arc;
+use std::pin::Pin;
 use uuid::Uuid;
 
 /// Identifier for a root supervisor and dead-letters children.
@@ -105,12 +106,12 @@ pub struct BastionContext {
     child: ChildRef,
     children: ChildrenRef,
     supervisor: Option<SupervisorRef>,
-    state: Qutex<ContextState>,
+    state: Qutex<Pin<Box<ContextState>>>,
 }
 
 #[derive(Debug)]
 pub(crate) struct ContextState {
-    msgs: VecDeque<SignedMessage>,
+    messages: VecDeque<SignedMessage>,
 }
 
 impl BastionId {
@@ -127,7 +128,7 @@ impl BastionContext {
         child: ChildRef,
         children: ChildrenRef,
         supervisor: Option<SupervisorRef>,
-        state: Qutex<ContextState>,
+        state: Qutex<Pin<Box<ContextState>>>,
     ) -> Self {
         debug!("BastionContext({}): Creating.", id);
         BastionContext {
@@ -304,9 +305,10 @@ impl BastionContext {
     pub async fn try_recv(&self) -> Option<SignedMessage> {
         debug!("BastionContext({}): Trying to receive message.", self.id);
         // TODO: Err(Error)
-        let mut state = self.state.clone().lock_async().await.ok()?;
+        let mut guard = self.state.clone().lock_async().await.ok()?;
+        let mut state = guard.as_mut();
 
-        if let Some(msg) = state.msgs.pop_front() {
+        if let Some(msg) = state.pop_message() {
             trace!("BastionContext({}): Received message: {:?}", self.id, msg);
             Some(msg)
         } else {
@@ -356,15 +358,15 @@ impl BastionContext {
         debug!("BastionContext({}): Waiting to receive message.", self.id);
         loop {
             // TODO: Err(Error)
-            let mut state = self.state.clone().lock_async().await.unwrap();
+            let mut guard = self.state.clone().lock_async().await.unwrap();
+            let mut state = guard.as_mut();
 
-            if let Some(msg) = state.msgs.pop_front() {
+            if let Some(msg) = state.pop_message() {
                 trace!("BastionContext({}): Received message: {:?}", self.id, msg);
                 return Ok(msg);
             }
 
-            Guard::unlock(state);
-
+            Guard::unlock(guard);
             pending!();
         }
     }
@@ -584,13 +586,17 @@ impl BastionContext {
 
 impl ContextState {
     pub(crate) fn new() -> Self {
-        let msgs = VecDeque::new();
-
-        ContextState { msgs }
+        ContextState {
+            messages: VecDeque::new()
+        }
     }
 
-    pub(crate) fn push_msg(&mut self, msg: Msg, sign: RefAddr) {
-        self.msgs.push_back(SignedMessage::new(msg, sign))
+    pub(crate) fn push_message(&mut self, msg: Msg, sign: RefAddr) {
+        self.messages.push_back(SignedMessage::new(msg, sign))
+    }
+
+    pub(crate) fn pop_message(&mut self) -> Option<SignedMessage> {
+        self.messages.pop_front()
     }
 }
 

--- a/bastion/src/message.rs
+++ b/bastion/src/message.rs
@@ -204,6 +204,10 @@ pub(crate) enum BastionMessage {
         id: BastionId,
         parent_id: BastionId,
     },
+    FinishedChild {
+        id: BastionId,
+        parent_id: BastionId,
+    },
     RestartSubtree,
     RestoreChild {
         id: BastionId,
@@ -446,6 +450,10 @@ impl BastionMessage {
         BastionMessage::RestartRequired { id, parent_id }
     }
 
+    pub(crate) fn finished_child(id: BastionId, parent_id: BastionId) -> Self {
+        BastionMessage::FinishedChild { id, parent_id }
+    }
+
     pub(crate) fn restart_subtree() -> Self {
         BastionMessage::RestartSubtree
     }
@@ -494,6 +502,9 @@ impl BastionMessage {
             BastionMessage::Message(msg) => BastionMessage::Message(msg.try_clone()?),
             BastionMessage::RestartRequired { id, parent_id } => {
                 BastionMessage::restart_required(id.clone(), parent_id.clone())
+            }
+            BastionMessage::FinishedChild { id, parent_id } => {
+                BastionMessage::finished_child(id.clone(), parent_id.clone())
             }
             BastionMessage::RestartSubtree => BastionMessage::restart_subtree(),
             BastionMessage::RestoreChild { id, state } => {

--- a/bastion/src/message.rs
+++ b/bastion/src/message.rs
@@ -6,6 +6,7 @@
 //! * All message communication relies on at-most-once delivery guarantee.
 //! * Messages are not guaranteed to be ordered, all message's order is causal.
 //!
+use crate::callbacks::CallbackType;
 use crate::children::Children;
 use crate::context::{BastionId, ContextState};
 use crate::envelope::{RefAddr, SignedMessage};
@@ -194,6 +195,7 @@ pub(crate) enum BastionMessage {
         id: BastionId,
     },
     SuperviseWith(SupervisionStrategy),
+    ApplyCallback(CallbackType),
     InstantiatedChild {
         parent_id: BastionId,
         child_id: BastionId,
@@ -419,6 +421,10 @@ impl BastionMessage {
         BastionMessage::SuperviseWith(strategy)
     }
 
+    pub(crate) fn apply_callback(callback_type: CallbackType) -> Self {
+        BastionMessage::ApplyCallback(callback_type)
+    }
+
     pub(crate) fn instantiated_child(
         parent_id: BastionId,
         child_id: BastionId,
@@ -489,6 +495,9 @@ impl BastionMessage {
             BastionMessage::Prune { id } => BastionMessage::prune(id.clone()),
             BastionMessage::SuperviseWith(strategy) => {
                 BastionMessage::supervise_with(strategy.clone())
+            }
+            BastionMessage::ApplyCallback(callback_type) => {
+                BastionMessage::apply_callback(callback_type.clone())
             }
             BastionMessage::InstantiatedChild {
                 parent_id,

--- a/bastion/src/message.rs
+++ b/bastion/src/message.rs
@@ -195,6 +195,9 @@ pub(crate) enum BastionMessage {
     InstantiatedChild { parent_id: BastionId, child_id: BastionId, state: Qutex<Pin<Box<ContextState>>> },
     Message(Msg),
     RestartRequired { id: BastionId, parent_id: BastionId},
+    RestoreChild { id: BastionId, state: Qutex<Pin<Box<ContextState>>> },
+    DropChild { id: BastionId },
+    SetState { state: Qutex<Pin<Box<ContextState>>> },
     Stopped { id: BastionId },
     Faulted { id: BastionId },
 }
@@ -418,6 +421,18 @@ impl BastionMessage {
         BastionMessage::RestartRequired { id, parent_id }
     }
 
+    pub(crate) fn restore_child(id: BastionId, state: Qutex<Pin<Box<ContextState>>>) -> Self {
+        BastionMessage::RestoreChild { id, state }
+    }
+
+    pub(crate) fn drop_child(id: BastionId) -> Self {
+        BastionMessage::DropChild { id }
+    }
+
+    pub(crate) fn set_state(state: Qutex<Pin<Box<ContextState>>>) -> Self {
+        BastionMessage::SetState { state }
+    }
+
     pub(crate) fn stopped(id: BastionId) -> Self {
         BastionMessage::Stopped { id }
     }
@@ -443,6 +458,9 @@ impl BastionMessage {
             }
             BastionMessage::Message(msg) => BastionMessage::Message(msg.try_clone()?),
             BastionMessage::RestartRequired { id, parent_id } => BastionMessage::restart_required(id.clone(), parent_id.clone()),
+            BastionMessage::RestoreChild { id, state } => BastionMessage::restore_child(id.clone(), state.clone()),
+            BastionMessage::DropChild { id } => BastionMessage::drop_child(id.clone()),
+            BastionMessage::SetState { state } => BastionMessage::set_state(state.clone()),
             BastionMessage::Stopped { id } => BastionMessage::stopped(id.clone()),
             BastionMessage::Faulted { id} => BastionMessage::faulted(id.clone()),
         };

--- a/bastion/src/message.rs
+++ b/bastion/src/message.rs
@@ -194,6 +194,7 @@ pub(crate) enum BastionMessage {
     SuperviseWith(SupervisionStrategy),
     InstantiatedChild { parent_id: BastionId, child_id: BastionId, state: Qutex<Pin<Box<ContextState>>> },
     Message(Msg),
+    RestartRequired { id: BastionId, parent_id: BastionId},
     Stopped { id: BastionId },
     Faulted { id: BastionId },
 }
@@ -413,6 +414,10 @@ impl BastionMessage {
         (BastionMessage::Message(msg), answer)
     }
 
+    pub(crate) fn restart_required(id: BastionId, parent_id: BastionId) -> Self {
+        BastionMessage::RestartRequired { id, parent_id }
+    }
+
     pub(crate) fn stopped(id: BastionId) -> Self {
         BastionMessage::Stopped { id }
     }
@@ -437,8 +442,9 @@ impl BastionMessage {
                 BastionMessage::instantiated_child(parent_id.clone(), child_id.clone(), state.clone())
             }
             BastionMessage::Message(msg) => BastionMessage::Message(msg.try_clone()?),
+            BastionMessage::RestartRequired { id, parent_id } => BastionMessage::restart_required(id.clone(), parent_id.clone()),
             BastionMessage::Stopped { id } => BastionMessage::stopped(id.clone()),
-            BastionMessage::Faulted { id } => BastionMessage::faulted(id.clone()),
+            BastionMessage::Faulted { id} => BastionMessage::faulted(id.clone()),
         };
 
         Some(clone)

--- a/bastion/src/message.rs
+++ b/bastion/src/message.rs
@@ -195,6 +195,7 @@ pub(crate) enum BastionMessage {
     InstantiatedChild { parent_id: BastionId, child_id: BastionId, state: Qutex<Pin<Box<ContextState>>> },
     Message(Msg),
     RestartRequired { id: BastionId, parent_id: BastionId},
+    RestartSubtree,
     RestoreChild { id: BastionId, state: Qutex<Pin<Box<ContextState>>> },
     DropChild { id: BastionId },
     SetState { state: Qutex<Pin<Box<ContextState>>> },
@@ -421,6 +422,10 @@ impl BastionMessage {
         BastionMessage::RestartRequired { id, parent_id }
     }
 
+    pub(crate) fn restart_subtree() -> Self {
+        BastionMessage::RestartSubtree
+    }
+
     pub(crate) fn restore_child(id: BastionId, state: Qutex<Pin<Box<ContextState>>>) -> Self {
         BastionMessage::RestoreChild { id, state }
     }
@@ -458,6 +463,7 @@ impl BastionMessage {
             }
             BastionMessage::Message(msg) => BastionMessage::Message(msg.try_clone()?),
             BastionMessage::RestartRequired { id, parent_id } => BastionMessage::restart_required(id.clone(), parent_id.clone()),
+            BastionMessage::RestartSubtree => BastionMessage::restart_subtree(),
             BastionMessage::RestoreChild { id, state } => BastionMessage::restore_child(id.clone(), state.clone()),
             BastionMessage::DropChild { id } => BastionMessage::drop_child(id.clone()),
             BastionMessage::SetState { state } => BastionMessage::set_state(state.clone()),

--- a/bastion/src/message.rs
+++ b/bastion/src/message.rs
@@ -190,17 +190,37 @@ pub(crate) enum BastionMessage {
     Stop,
     Kill,
     Deploy(Deployment),
-    Prune { id: BastionId },
+    Prune {
+        id: BastionId,
+    },
     SuperviseWith(SupervisionStrategy),
-    InstantiatedChild { parent_id: BastionId, child_id: BastionId, state: Qutex<Pin<Box<ContextState>>> },
+    InstantiatedChild {
+        parent_id: BastionId,
+        child_id: BastionId,
+        state: Qutex<Pin<Box<ContextState>>>,
+    },
     Message(Msg),
-    RestartRequired { id: BastionId, parent_id: BastionId},
+    RestartRequired {
+        id: BastionId,
+        parent_id: BastionId,
+    },
     RestartSubtree,
-    RestoreChild { id: BastionId, state: Qutex<Pin<Box<ContextState>>> },
-    DropChild { id: BastionId },
-    SetState { state: Qutex<Pin<Box<ContextState>>> },
-    Stopped { id: BastionId },
-    Faulted { id: BastionId },
+    RestoreChild {
+        id: BastionId,
+        state: Qutex<Pin<Box<ContextState>>>,
+    },
+    DropChild {
+        id: BastionId,
+    },
+    SetState {
+        state: Qutex<Pin<Box<ContextState>>>,
+    },
+    Stopped {
+        id: BastionId,
+    },
+    Faulted {
+        id: BastionId,
+    },
 }
 
 #[derive(Debug)]
@@ -398,9 +418,13 @@ impl BastionMessage {
     pub(crate) fn instantiated_child(
         parent_id: BastionId,
         child_id: BastionId,
-        state: Qutex<Pin<Box<ContextState>>>
+        state: Qutex<Pin<Box<ContextState>>>,
     ) -> Self {
-        BastionMessage::InstantiatedChild { parent_id, child_id, state }
+        BastionMessage::InstantiatedChild {
+            parent_id,
+            child_id,
+            state,
+        }
     }
 
     pub(crate) fn broadcast<M: Message>(msg: M) -> Self {
@@ -458,17 +482,27 @@ impl BastionMessage {
             BastionMessage::SuperviseWith(strategy) => {
                 BastionMessage::supervise_with(strategy.clone())
             }
-            BastionMessage::InstantiatedChild { parent_id, child_id, state } => {
-                BastionMessage::instantiated_child(parent_id.clone(), child_id.clone(), state.clone())
-            }
+            BastionMessage::InstantiatedChild {
+                parent_id,
+                child_id,
+                state,
+            } => BastionMessage::instantiated_child(
+                parent_id.clone(),
+                child_id.clone(),
+                state.clone(),
+            ),
             BastionMessage::Message(msg) => BastionMessage::Message(msg.try_clone()?),
-            BastionMessage::RestartRequired { id, parent_id } => BastionMessage::restart_required(id.clone(), parent_id.clone()),
+            BastionMessage::RestartRequired { id, parent_id } => {
+                BastionMessage::restart_required(id.clone(), parent_id.clone())
+            }
             BastionMessage::RestartSubtree => BastionMessage::restart_subtree(),
-            BastionMessage::RestoreChild { id, state } => BastionMessage::restore_child(id.clone(), state.clone()),
+            BastionMessage::RestoreChild { id, state } => {
+                BastionMessage::restore_child(id.clone(), state.clone())
+            }
             BastionMessage::DropChild { id } => BastionMessage::drop_child(id.clone()),
             BastionMessage::SetState { state } => BastionMessage::set_state(state.clone()),
             BastionMessage::Stopped { id } => BastionMessage::stopped(id.clone()),
-            BastionMessage::Faulted { id} => BastionMessage::faulted(id.clone()),
+            BastionMessage::Faulted { id } => BastionMessage::faulted(id.clone()),
         };
 
         Some(clone)

--- a/bastion/src/path.rs
+++ b/bastion/src/path.rs
@@ -318,14 +318,6 @@ impl BastionPathElement {
         }
     }
 
-    pub(crate) fn with_id(self, id: BastionId) -> Self {
-        match self {
-            BastionPathElement::Supervisor(_) => BastionPathElement::Supervisor(id),
-            BastionPathElement::Children(_) => BastionPathElement::Children(id),
-            BastionPathElement::Child(_) => BastionPathElement::Child(id),
-        }
-    }
-
     #[doc(hidden)]
     /// Checks whether the BastionPath identifies a supervisor.
     pub fn is_supervisor(&self) -> bool {

--- a/bastion/src/supervisor.rs
+++ b/bastion/src/supervisor.rs
@@ -862,7 +862,7 @@ impl Supervisor {
                         false => {
                             self.remove_child(&id.clone(), &parent_id.clone());
                             BastionMessage::drop_child(id)
-                        },
+                        }
                     };
                     let restart_strategy = self.restart_strategy.clone();
 
@@ -897,7 +897,7 @@ impl Supervisor {
         for (new_index, state) in childs.iter().enumerate() {
             let child_id = state.id.clone();
             self.tracked_groups_order.insert(child_id, new_index);
-        };
+        }
     }
 
     async fn stop(&mut self, range: Range<usize>) {
@@ -1795,31 +1795,6 @@ impl Supervised {
         ProcStack::default()
     }
 
-    fn reset(self, bcast: Broadcast) -> RecoverableHandle<Self> {
-        debug!(
-            "Supervised({}): Resetting to Supervised({}).",
-            self.id(),
-            bcast.id()
-        );
-        let stack = self.stack();
-        match self {
-            Supervised::Supervisor(mut supervisor) => pool::spawn(
-                async {
-                    supervisor.reset(Some(bcast)).await;
-                    Supervised::Supervisor(supervisor)
-                },
-                stack,
-            ),
-            Supervised::Children(mut children) => pool::spawn(
-                async {
-                    children.reset(bcast).await;
-                    Supervised::Children(children)
-                },
-                stack,
-            ),
-        }
-    }
-
     fn id(&self) -> &BastionId {
         match self {
             Supervised::Supervisor(supervisor) => supervisor.id(),
@@ -1831,16 +1806,6 @@ impl Supervised {
         match self {
             Supervised::Supervisor(supervisor) => supervisor.bcast(),
             Supervised::Children(children) => children.bcast(),
-        }
-    }
-
-    pub(crate) fn elem(&self) -> &BastionPathElement {
-        match self {
-            // FIXME
-            Supervised::Supervisor(supervisor) => {
-                supervisor.bcast().path().elem().as_ref().unwrap()
-            }
-            Supervised::Children(children) => children.bcast().path().elem().as_ref().unwrap(),
         }
     }
 

--- a/bastion/src/supervisor.rs
+++ b/bastion/src/supervisor.rs
@@ -107,6 +107,12 @@ struct TrackedChildState {
     restarts_counts: usize,
 }
 
+#[derive(Debug)]
+enum RestartedElement {
+    Supervisor(BastionId),
+    Children(BastionId),
+}
+
 #[derive(Debug, Clone)]
 /// A "reference" to a [`Supervisor`], allowing to
 /// communicate with it.
@@ -1163,12 +1169,17 @@ impl Supervisor {
                 );
                 self.bcast.send_children(env);
             }
+            // TODO: ADD implementation
             Envelope {
-                msg: BastionMessage::Stopped { id },
+                msg: BastionMessage::RestartRequired { id, parent_id },
+                ..
+            } => unimplemented!(),
+            Envelope {
+                msg: BastionMessage::Stopped { id, .. },
                 ..
             } => self.cleanup_supervised_object(id).await,
             Envelope {
-                msg: BastionMessage::Faulted { id },
+                msg: BastionMessage::Faulted { id, .. },
                 ..
             } => {
                 if self.recover_supervised_object(id).await.is_err() {

--- a/bastion/src/supervisor.rs
+++ b/bastion/src/supervisor.rs
@@ -1215,6 +1215,10 @@ impl Supervisor {
                 }
             }
             Envelope {
+                msg: BastionMessage::RestartSubtree,
+                ..
+            } => unimplemented!(),
+            Envelope {
                 msg: BastionMessage::RestoreChild { .. },
                 ..
             } => unreachable!(),

--- a/bastion/src/supervisor.rs
+++ b/bastion/src/supervisor.rs
@@ -874,7 +874,7 @@ impl Supervisor {
             }
         }
 
-        for (receiver, msg) in restart_futures.next().await {
+        while let Some((receiver, msg)) = restart_futures.next().await {
             let env = Envelope::new(msg, self.bcast.path().clone(), self.bcast.sender().clone());
             self.bcast.send_child(&receiver, env);
         }

--- a/bastion/src/supervisor.rs
+++ b/bastion/src/supervisor.rs
@@ -859,7 +859,14 @@ impl Supervisor {
                             let state = tracked_state.state();
                             BastionMessage::restore_child(id, state)
                         }
-                        false => BastionMessage::drop_child(id),
+                        false => {
+                            childs.remove(index);
+                            for (new_index, state) in childs.iter().enumerate() {
+                                let child_id = state.id.clone();
+                                self.tracked_groups_order.insert(child_id, new_index);
+                            };
+                            BastionMessage::drop_child(id)
+                        },
                     };
                     let restart_strategy = self.restart_strategy.clone();
 

--- a/bastion/src/supervisor.rs
+++ b/bastion/src/supervisor.rs
@@ -829,9 +829,6 @@ impl Supervisor {
                         Envelope::new(msg, self.bcast.path().clone(), self.bcast.sender().clone());
                     self.bcast.send_child(&supervisor_id, env);
                 }
-                // FIXME: supervised.callbacks().before_restart() calls for the specific actor?
-                // FIXME: supervised.callbacks().before_start() calls for the specific actor?
-                // FIXME: supervised.callbacks().after_restart() calls for the specific actor?
                 RestartedElement::Child { id, parent_id } => {
                     let index = match self.tracked_groups_order.get(&id) {
                         Some(index) => *index,
@@ -1227,6 +1224,10 @@ impl Supervisor {
                 );
                 self.strategy = strategy;
             }
+            Envelope {
+                msg: BastionMessage::ApplyCallback { .. },
+                ..
+            } => unreachable!(),
             Envelope {
                 msg:
                     BastionMessage::InstantiatedChild {

--- a/bastion/src/system.rs
+++ b/bastion/src/system.rs
@@ -344,6 +344,18 @@ impl System {
                 ..
             } => unreachable!(),
             Envelope {
+                msg: BastionMessage::RestoreChild { .. },
+                ..
+            } => unreachable!(),
+            Envelope {
+                msg: BastionMessage::DropChild { .. },
+                ..
+            } => unreachable!(),
+            Envelope {
+                msg: BastionMessage::SetState { .. },
+                ..
+            } => unreachable!(),
+            Envelope {
                 msg: BastionMessage::Stopped { id, .. },
                 ..
             } => self.restart_supervised_object(id),

--- a/bastion/src/system.rs
+++ b/bastion/src/system.rs
@@ -344,6 +344,10 @@ impl System {
                 ..
             } => unreachable!(),
             Envelope {
+                msg: BastionMessage::RestartSubtree,
+                ..
+            } => unreachable!(),
+            Envelope {
                 msg: BastionMessage::RestoreChild { .. },
                 ..
             } => unreachable!(),

--- a/bastion/src/system.rs
+++ b/bastion/src/system.rs
@@ -340,11 +340,15 @@ impl System {
                 self.bcast.send_children(env);
             }
             Envelope {
-                msg: BastionMessage::Stopped { id },
+                msg: BastionMessage::RestartRequired { .. },
+                ..
+            } => unreachable!(),
+            Envelope {
+                msg: BastionMessage::Stopped { id, .. },
                 ..
             } => self.restart_supervised_object(id),
             Envelope {
-                msg: BastionMessage::Faulted { id },
+                msg: BastionMessage::Faulted { id, .. },
                 ..
             } => self.restart_supervised_object(id),
         }

--- a/bastion/src/system.rs
+++ b/bastion/src/system.rs
@@ -329,6 +329,10 @@ impl System {
                 ..
             } => unimplemented!(),
             Envelope {
+                msg: BastionMessage::ApplyCallback { .. },
+                ..
+            } => unreachable!(),
+            Envelope {
                 msg: BastionMessage::InstantiatedChild { .. },
                 ..
             } => unreachable!(),

--- a/bastion/src/system.rs
+++ b/bastion/src/system.rs
@@ -352,6 +352,10 @@ impl System {
                 ..
             } => unreachable!(),
             Envelope {
+                msg: BastionMessage::FinishedChild { .. },
+                ..
+            } => unreachable!(),
+            Envelope {
                 msg: BastionMessage::DropChild { .. },
                 ..
             } => unreachable!(),

--- a/bastion/src/system.rs
+++ b/bastion/src/system.rs
@@ -329,6 +329,10 @@ impl System {
                 ..
             } => unimplemented!(),
             Envelope {
+                msg: BastionMessage::InstantiatedChild { .. },
+                ..
+            } => unreachable!(),
+            Envelope {
                 msg: BastionMessage::Message(ref message),
                 ..
             } => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bastion-rs/.github/blob/master/CONTRIBUTING.md
-->

The following feature adds a support for preserving failed actors mailboxes and re-assigned them between restarts. However, those changes require an extensive refactoring of the existing codebase, especially the restart approach that we had before.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are passing with `cargo test`. 
- [x] documentation is changed or added
- [x] commit message is clear

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
