### PR TITLE
Autoscaling actor groups in runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,20 +66,21 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all
+          args: --all --all-features
 
       - name: tests windows
         if: matrix.os == 'windows-latest'
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --all-features
 
       - name: tests nightly osx
         if: ${{ matrix.version == 'nightly' && matrix.os == 'macOS-latest' }}
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all
+          args: --all --all-features
 
       - name: tests nightly linux
         if: ${{ matrix.version == 'nightly' && matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,14 +66,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --all-features
+          args: --all
 
       - name: tests windows
         if: matrix.os == 'windows-latest'
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features
 
       - name: tests nightly osx
         if: ${{ matrix.version == 'nightly' && matrix.os == 'macOS-latest' }}

--- a/src/bastion/Cargo.toml
+++ b/src/bastion/Cargo.toml
@@ -41,12 +41,14 @@ unstable = ["bastion-executor/unstable"]
 distributed = [
   "artillery-core"
 ]
-docs = ["distributed", "default"]
+scaling = []
+docs = ["distributed", "scaling", "default"]
 
 
 [package.metadata.docs.rs]
 features = ["docs"]
 rustdoc-args = ["--cfg", "feature=\"docs\""]
+
 
 [dependencies]
 bastion-executor = { version = "= 0.3.5-alpha", path = "../bastion-executor" }

--- a/src/bastion/Cargo.toml
+++ b/src/bastion/Cargo.toml
@@ -67,7 +67,7 @@ async-mutex = "1.1"
 uuid = { version = "0.8", features = ["v4"] }
 
 # Distributed
-artillery-core = { version = "0.1.0", optional = true }
+artillery-core = { version = "0.1.2-alpha.1", optional = true }
 
 # Log crates
 tracing-subscriber = "0.2.6"

--- a/src/bastion/Cargo.toml
+++ b/src/bastion/Cargo.toml
@@ -54,7 +54,7 @@ rustdoc-args = ["--cfg", "feature=\"docs\""]
 bastion-executor = { version = "= 0.3.5-alpha", path = "../bastion-executor" }
 lightproc = { version = "= 0.3.5-alpha.0", path = "../lightproc" }
 
-lever = "0.1.1-alpha.3"
+lever = "0.1.1-alpha.7"
 futures = "0.3.5"
 futures-timer = "3.0.2"
 fxhash = "0.2"

--- a/src/bastion/Cargo.toml
+++ b/src/bastion/Cargo.toml
@@ -54,7 +54,7 @@ rustdoc-args = ["--cfg", "feature=\"docs\""]
 bastion-executor = { version = "= 0.3.5-alpha", path = "../bastion-executor" }
 lightproc = { version = "= 0.3.5-alpha.0", path = "../lightproc" }
 
-lever = "0.1.1-alpha.7"
+lever = "0.1.1-alpha.8"
 futures = "0.3.5"
 futures-timer = "3.0.2"
 fxhash = "0.2"

--- a/src/bastion/examples/scaling_groups.rs
+++ b/src/bastion/examples/scaling_groups.rs
@@ -62,19 +62,19 @@ fn input_group(children: Children) -> Children {
 
 fn auto_resize_group(children: Children) -> Children {
     children
-        .with_redundancy(3)                                // Start with 3 actors
-        .with_heartbeat_tick(Duration::from_secs(5))       // Do heartbeat each 5 seconds
+        .with_redundancy(3) // Start with 3 actors
+        .with_heartbeat_tick(Duration::from_secs(5)) // Do heartbeat each 5 seconds
         .with_resizer(
             OptimalSizeExploringResizer::default()
-                .with_lower_bound(0)                       // A minimal acceptable size of group
-                .with_upper_bound(UpperBound::Limit(10))   // Max 10 actors in runtime
+                .with_lower_bound(0) // A minimal acceptable size of group
+                .with_upper_bound(UpperBound::Limit(10)) // Max 10 actors in runtime
                 .with_upscale_strategy(UpscaleStrategy::MailboxSizeThreshold(3)) // Scale up when a half of actors have more then 3 messages
-                .with_upscale_rate(0.1)                    // Increase the size of group on 10%, if necessary to scale up
-                .with_downscale_rate(0.2)                  // Decrease the size of group on 20%, if too many free actors
+                .with_upscale_rate(0.1) // Increase the size of group on 10%, if necessary to scale up
+                .with_downscale_rate(0.2), // Decrease the size of group on 20%, if too many free actors
         )
-        .with_dispatcher(
-            Dispatcher::with_type(DispatcherType::Named("Processing".to_string())),
-        )
+        .with_dispatcher(Dispatcher::with_type(DispatcherType::Named(
+            "Processing".to_string(),
+        )))
         .with_exec(move |ctx: BastionContext| async move {
             println!("[Processing] Worker started!");
 

--- a/src/bastion/examples/scaling_groups.rs
+++ b/src/bastion/examples/scaling_groups.rs
@@ -45,12 +45,12 @@ fn input_group(children: Children) -> Children {
             let group_name = "Processing".to_string();
             let target = BroadcastTarget::Group(group_name);
 
-            while messages_sent != 10000 {
+            while messages_sent != 100 {
                 // Emulate the workload. The number means how
                 // long it must wait before processing.
                 for value in INPUT.iter() {
                     ctx.broadcast_message(target.clone(), value);
-                    Delay::new(Duration::from_millis(500 * value)).await;
+                    Delay::new(Duration::from_millis(450 * value)).await;
                 }
 
                 messages_sent += INPUT.len();
@@ -63,6 +63,7 @@ fn input_group(children: Children) -> Children {
 fn auto_resize_group(children: Children) -> Children {
     children
         .with_redundancy(3)                                // Start with 3 actors
+        .with_heartbeat_tick(Duration::from_secs(5))       // Do heartbeat each 5 seconds
         .with_resizer(
             OptimalSizeExploringResizer::default()
                 .with_lower_bound(0)                       // A minimal acceptable size of group
@@ -91,7 +92,7 @@ fn auto_resize_group(children: Children) -> Children {
                             ref number: &'static u64 => {
                                 // Emulate some processing. The received number is a delay.
                                 println!("[Processing] Worker #{:?} received `{}`", ctx.current().id(), number);
-                                Delay::new(Duration::from_secs(**number)).await;
+                                Delay::new(Duration::from_millis(**number * 500)).await;
                             };
                             _: _ => ();
                         }

--- a/src/bastion/examples/scaling_groups.rs
+++ b/src/bastion/examples/scaling_groups.rs
@@ -45,12 +45,12 @@ fn input_group(children: Children) -> Children {
             let group_name = "Processing".to_string();
             let target = BroadcastTarget::Group(group_name);
 
-            while messages_sent != 100 {
+            while messages_sent != 1000 {
                 // Emulate the workload. The number means how
                 // long it must wait before processing.
                 for value in INPUT.iter() {
                     ctx.broadcast_message(target.clone(), value);
-                    Delay::new(Duration::from_millis(450 * value)).await;
+                    Delay::new(Duration::from_millis(75 * value)).await;
                 }
 
                 messages_sent += INPUT.len();
@@ -66,7 +66,7 @@ fn auto_resize_group(children: Children) -> Children {
         .with_heartbeat_tick(Duration::from_secs(5)) // Do heartbeat each 5 seconds
         .with_resizer(
             OptimalSizeExploringResizer::default()
-                .with_lower_bound(0) // A minimal acceptable size of group
+                .with_lower_bound(1) // A minimal acceptable size of group
                 .with_upper_bound(UpperBound::Limit(10)) // Max 10 actors in runtime
                 .with_upscale_strategy(UpscaleStrategy::MailboxSizeThreshold(3)) // Scale up when a half of actors have more then 3 messages
                 .with_upscale_rate(0.1) // Increase the size of group on 10%, if necessary to scale up
@@ -108,6 +108,7 @@ fn auto_resize_group(children: Children) -> Children {
                 );
             }
 
+            println!("[Processing] Worker finished!");
             Ok(())
         })
 }

--- a/src/bastion/examples/scaling_groups.rs
+++ b/src/bastion/examples/scaling_groups.rs
@@ -45,12 +45,12 @@ fn input_group(children: Children) -> Children {
             let group_name = "Processing".to_string();
             let target = BroadcastTarget::Group(group_name);
 
-            while messages_sent != 25 {
+            while messages_sent != 10000 {
                 // Emulate the workload. The number means how
                 // long it must wait before processing.
                 for value in INPUT.iter() {
                     ctx.broadcast_message(target.clone(), value);
-                    Delay::new(Duration::from_millis(500)).await;
+                    Delay::new(Duration::from_millis(500 * value)).await;
                 }
 
                 messages_sent += INPUT.len();
@@ -78,7 +78,7 @@ fn auto_resize_group(children: Children) -> Children {
             println!("[Processing] Worker started!");
 
             let mut messages_received = 0;
-            let messages_limit = 10;
+            let messages_limit = 25;
 
             while messages_received != messages_limit {
                 msg! { ctx.recv().await?,
@@ -100,6 +100,11 @@ fn auto_resize_group(children: Children) -> Children {
                 }
 
                 messages_received += 1;
+                println!(
+                    "[Processing] Worker #{:?} processed {} message(s)",
+                    ctx.current().id(),
+                    messages_received
+                );
             }
 
             Ok(())

--- a/src/bastion/examples/scaling_groups.rs
+++ b/src/bastion/examples/scaling_groups.rs
@@ -93,7 +93,7 @@ fn auto_resize_group(children: Children) -> Children {
                             ref number: &'static u64 => {
                                 // Emulate some processing. The received number is a delay.
                                 println!("[Processing] Worker #{:?} received `{}`", ctx.current().id(), number);
-                                Delay::new(Duration::from_millis(**number)).await;
+                                Delay::new(Duration::from_millis(**number * 500)).await;
                             };
                             _: _ => ();
                         }

--- a/src/bastion/examples/scaling_groups.rs
+++ b/src/bastion/examples/scaling_groups.rs
@@ -64,7 +64,7 @@ fn auto_resize_group(children: Children) -> Children {
     children
         .with_redundancy(3)                                // Start with 3 actors
         .with_resizer(
-            Resizer::default()
+            OptimalSizeExploringResizer::default()
                 .with_lower_bound(0)                       // A minimal acceptable size of group
                 .with_upper_bound(UpperBound::Limit(10))   // Max 10 actors in runtime
                 .with_upscale_strategy(UpscaleStrategy::MailboxSizeThreshold(3)) // Scale up when a half of actors have more then 3 messages

--- a/src/bastion/examples/scaling_groups.rs
+++ b/src/bastion/examples/scaling_groups.rs
@@ -37,6 +37,7 @@ fn auto_resize_group_supervisor(supervisor: Supervisor) -> Supervisor {
 fn input_group(children: Children) -> Children {
     children
         .with_redundancy(1)
+        .with_resizer(OptimalSizeExploringResizer::default().with_lower_bound(0)) // Don't start new actors after finishing execution
         .with_exec(move |ctx: BastionContext| async move {
             println!("[Input] Worker started!");
 
@@ -68,7 +69,7 @@ fn auto_resize_group(children: Children) -> Children {
             OptimalSizeExploringResizer::default()
                 .with_lower_bound(1) // A minimal acceptable size of group
                 .with_upper_bound(UpperBound::Limit(10)) // Max 10 actors in runtime
-                .with_upscale_strategy(UpscaleStrategy::MailboxSizeThreshold(3)) // Scale up when a half of actors have more then 3 messages
+                .with_upscale_strategy(UpscaleStrategy::MailboxSizeThreshold(3)) // Scale up when a half of actors have more than 3 messages
                 .with_upscale_rate(0.1) // Increase the size of group on 10%, if necessary to scale up
                 .with_downscale_rate(0.2), // Decrease the size of group on 20%, if too many free actors
         )
@@ -92,7 +93,7 @@ fn auto_resize_group(children: Children) -> Children {
                             ref number: &'static u64 => {
                                 // Emulate some processing. The received number is a delay.
                                 println!("[Processing] Worker #{:?} received `{}`", ctx.current().id(), number);
-                                Delay::new(Duration::from_millis(**number * 500)).await;
+                                Delay::new(Duration::from_millis(**number)).await;
                             };
                             _: _ => ();
                         }

--- a/src/bastion/examples/scaling_groups.rs
+++ b/src/bastion/examples/scaling_groups.rs
@@ -1,0 +1,107 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use bastion::prelude::*;
+use futures_timer::Delay;
+
+///
+/// An example with the usage of the rescaling actor groups in runtime.
+/// P.S. For running this example you will need to set the `scaling` feature flag.
+///
+/// Prologue:
+/// This example demonstrates how developers can use Resizer instances for
+/// auto scaling up and down actor groups based on the specified thresholds
+/// for the actor mailboxes.
+///
+fn main() {
+    Bastion::init();
+
+    Bastion::supervisor(input_supervisor)
+        .and_then(|_| Bastion::supervisor(auto_resize_group_supervisor))
+        .expect("Couldn't create supervisor chain.");
+
+    Bastion::start();
+    Bastion::block_until_stopped();
+}
+
+// Supervisor that tracks only the single actor with input data
+fn input_supervisor(supervisor: Supervisor) -> Supervisor {
+    supervisor.children(|children| input_group(children))
+}
+
+// Supervisor that tracks the actor group with rescaling in runtime.
+fn auto_resize_group_supervisor(supervisor: Supervisor) -> Supervisor {
+    supervisor.children(|children| auto_resize_group(children))
+}
+
+fn input_group(children: Children) -> Children {
+    children
+        .with_redundancy(1)
+        .with_exec(move |ctx: BastionContext| async move {
+            println!("[Input] Worker started!");
+
+            let mut messages_sent = 0;
+            static INPUT: [u64; 5] = [5u64, 1, 2, 4, 3];
+            let group_name = "Processing".to_string();
+            let target = BroadcastTarget::Group(group_name);
+
+            while messages_sent != 25 {
+                // Emulate the workload. The number means how
+                // long it must wait before processing.
+                for value in INPUT.iter() {
+                    ctx.broadcast_message(target.clone(), value);
+                    Delay::new(Duration::from_millis(500)).await;
+                }
+
+                messages_sent += INPUT.len();
+            }
+
+            Ok(())
+        })
+}
+
+fn auto_resize_group(children: Children) -> Children {
+    children
+        .with_redundancy(3)                                // Start with 3 actors
+        .with_resizer(
+            Resizer::default()
+                .with_lower_bound(0)                       // A minimal acceptable size of group
+                .with_upper_bound(UpperBound::Limit(10))   // Max 10 actors in runtime
+                .with_upscale_strategy(UpscaleStrategy::MailboxSizeThreshold(3)) // Scale up when a half of actors have more then 3 messages
+                .with_upscale_rate(0.1)                    // Increase the size of group on 10%, if necessary to scale up
+                .with_downscale_rate(0.2)                  // Decrease the size of group on 20%, if too many free actors
+        )
+        .with_dispatcher(
+            Dispatcher::with_type(DispatcherType::Named("Processing".to_string())),
+        )
+        .with_exec(move |ctx: BastionContext| async move {
+            println!("[Processing] Worker started!");
+
+            let mut messages_received = 0;
+            let messages_limit = 10;
+
+            while messages_received != messages_limit {
+                msg! { ctx.recv().await?,
+                    // We received the message from other actor wrapped in Arc<T>
+                    // Let's unwrap it and do regular matching.
+                    raw_message: Arc<SignedMessage> => {
+                        let message = Arc::try_unwrap(raw_message).unwrap();
+
+                        msg! { message,
+                            ref number: &'static u64 => {
+                                // Emulate some processing. The received number is a delay.
+                                println!("[Processing] Worker #{:?} received `{}`", ctx.current().id(), number);
+                                Delay::new(Duration::from_secs(**number)).await;
+                            };
+                            _: _ => ();
+                        }
+                    };
+                    _: _ => ();
+                }
+
+                messages_received += 1;
+            }
+
+            Ok(())
+        })
+}

--- a/src/bastion/src/broadcast.rs
+++ b/src/bastion/src/broadcast.rs
@@ -34,17 +34,11 @@ pub(crate) enum Parent {
 
 impl Parent {
     pub(super) fn is_none(&self) -> bool {
-        match self {
-            Parent::None => true,
-            _ => false,
-        }
+        matches!(self, Parent::None)
     }
 
     pub(super) fn is_system(&self) -> bool {
-        match self {
-            Parent::System => true,
-            _ => false,
-        }
+        matches!(self, Parent::System)
     }
 }
 

--- a/src/bastion/src/child.rs
+++ b/src/bastion/src/child.rs
@@ -18,7 +18,6 @@ use futures::prelude::*;
 use lightproc::prelude::*;
 use lightproc::proc_state::EmptyProcState;
 use std::fmt::{self, Debug, Formatter};
-use std::fs::read_to_string;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -234,6 +233,10 @@ impl Child {
                 msg: BastionMessage::Faulted { .. },
                 ..
             } => unimplemented!(),
+            Envelope {
+                msg: BastionMessage::Heartbeat,
+                ..
+            } => unreachable!(),
         }
 
         Ok(())

--- a/src/bastion/src/child.rs
+++ b/src/bastion/src/child.rs
@@ -297,6 +297,9 @@ impl Child {
         let mut stats = ActorGroupStats::load(storage.clone());
         stats.update_average_mailbox_size(context_state.mailbox_size());
         stats.store(storage);
+
+        let actor_stats_table = guard.actor_stats();
+        actor_stats_table.insert(self.bcast.id().clone(), context_state.mailbox_size());
     }
 
     async fn run(mut self) {

--- a/src/bastion/src/child.rs
+++ b/src/bastion/src/child.rs
@@ -288,17 +288,7 @@ impl Child {
 
     #[cfg(feature = "scaling")]
     async fn update_stats(&mut self) {
-        let guard = match self.state.clone().lock_async().await {
-            Ok(guard) => guard,
-            Err(err) => {
-                debug!(
-                    "Child({:?}) Can't update stats. Reason: {:?}",
-                    self.bcast.id(),
-                    err
-                );
-                return;
-            }
-        };
+        let guard = self.state.lock().await;
         let context_state = guard.as_ref();
         let storage = guard.stats();
 
@@ -426,17 +416,7 @@ impl Child {
 
     #[cfg(feature = "scaling")]
     async fn cleanup_actors_stats(&mut self) {
-        let guard = match self.state.clone().lock_async().await {
-            Ok(guard) => guard,
-            Err(err) => {
-                debug!(
-                    "Child({:?}) Can't cleanup stats. Reason: {:?}",
-                    self.bcast.id(),
-                    err
-                );
-                return;
-            }
-        };
+        let guard = self.state.lock().await;
         let actor_stats_table = guard.actor_stats();
         actor_stats_table.remove(&self.bcast.id().clone()).ok();
     }

--- a/src/bastion/src/children.rs
+++ b/src/bastion/src/children.rs
@@ -898,6 +898,10 @@ impl Children {
 
         self.bcast.register(&bcast);
 
+        let msg = BastionMessage::start();
+        let env = Envelope::new(msg, self.bcast.path().clone(), self.bcast.sender().clone());
+        self.bcast.send_child(&id, env);
+
         debug!(
             "Children({}): Initializing Child({}).",
             self.id(),

--- a/src/bastion/src/children.rs
+++ b/src/bastion/src/children.rs
@@ -790,6 +790,8 @@ impl Children {
         let mut stats = ActorGroupStats::load(self.resizer.stats());
         stats.update_actors_count(self.launched.len() as u32);
         stats.store(self.resizer.stats());
+
+        println!("Active workers: {} [{}]", self.launched.len(), self.id());
     }
 
     #[cfg(feature = "scaling")]
@@ -937,11 +939,7 @@ impl Children {
         let children = self.as_ref();
         let supervisor = self.bcast.parent().clone().into_supervisor();
 
-        let mut state = ContextState::new();
-        #[cfg(feature = "scaling")]
-        self.init_data_for_scaling(&mut state);
-
-        let state = Qutex::new(Box::pin(state));
+        let state = Qutex::new(Box::pin(ContextState::new()));
 
         let ctx = BastionContext::new(
             id.clone(),

--- a/src/bastion/src/children.rs
+++ b/src/bastion/src/children.rs
@@ -811,6 +811,12 @@ impl Children {
         self.update_actors_count_stats();
     }
 
+    #[cfg(feature = "scaling")]
+    fn init_data_for_scaling(&self, state: &mut ContextState) {
+        state.with_stats(self.resizer.stats());
+        state.with_actor_stats(self.resizer.actor_stats());
+    }
+
     async fn run(mut self) -> Self {
         debug!("Children({}): Launched.", self.id());
 
@@ -879,7 +885,10 @@ impl Children {
         let children = self.as_ref();
         let supervisor = self.bcast.parent().clone().into_supervisor();
 
-        let state = ContextState::new().with_stats(self.resizer.stats());
+        let mut state = ContextState::new();
+        #[cfg(feature = "scaling")]
+        self.init_data_for_scaling(&mut state);
+
         let state = Arc::new(Mutex::new(Box::pin(state)));
 
         let ctx = BastionContext::new(
@@ -928,7 +937,10 @@ impl Children {
         let children = self.as_ref();
         let supervisor = self.bcast.parent().clone().into_supervisor();
 
-        let state = ContextState::new().with_stats(self.resizer.stats());
+        let mut state = ContextState::new();
+        #[cfg(feature = "scaling")]
+        self.init_data_for_scaling(&mut state);
+
         let state = Qutex::new(Box::pin(state));
 
         let ctx = BastionContext::new(

--- a/src/bastion/src/children.rs
+++ b/src/bastion/src/children.rs
@@ -485,7 +485,7 @@ impl Children {
         self
     }
 
-    // Returns executable code for the actor that will trigger heartbeat
+    /// Returns executable code for the actor that will trigger heartbeat
     fn get_heartbeat_fut(&self) -> Init {
         let interval = self.hearbeat_tick;
 

--- a/src/bastion/src/children.rs
+++ b/src/bastion/src/children.rs
@@ -11,7 +11,7 @@ use crate::envelope::Envelope;
 use crate::message::BastionMessage;
 use crate::path::BastionPathElement;
 #[cfg(feature = "scaling")]
-use crate::resizer::Resizer;
+use crate::resizer::{ActorGroupStats, Resizer};
 use crate::system::SYSTEM;
 use anyhow::Result as AnyResult;
 use async_mutex::Mutex;
@@ -686,8 +686,18 @@ impl Children {
         Ok(())
     }
 
+    #[cfg(feature = "scaling")]
+    fn collect_preliminary_stats(&self) {
+        let mut stats = ActorGroupStats::load(self.resizer.stats());
+        stats.update_actors_count(self.launched.len() as u32);
+        stats.store(self.resizer.stats());
+    }
+
     async fn run(mut self) -> Self {
         debug!("Children({}): Launched.", self.id());
+
+        #[cfg(feature = "scaling")]
+        self.collect_preliminary_stats();
 
         loop {
             #[cfg(feature = "scaling")]

--- a/src/bastion/src/children.rs
+++ b/src/bastion/src/children.rs
@@ -487,7 +487,7 @@ impl Children {
 
     // Returns executable code for the actor that will trigger heartbeat
     fn get_heartbeat_fut(&self) -> Init {
-        let interval = self.hearbeat_tick.clone();
+        let interval = self.hearbeat_tick;
 
         let exec_fut = move |ctx: BastionContext| async move {
             let self_path = ctx.current().path();
@@ -882,7 +882,7 @@ impl Children {
         let id = bcast.id().clone();
         let sender = bcast.sender().clone();
         let path = bcast.path().clone();
-        let child_ref = ChildRef::new(id.clone(), sender.clone(), name.clone(), path);
+        let child_ref = ChildRef::new(id.clone(), sender.clone(), name, path);
 
         let children = self.as_ref();
         let supervisor = self.bcast.parent().clone().into_supervisor();
@@ -936,20 +936,14 @@ impl Children {
         let id = bcast.id().clone();
         let sender = bcast.sender().clone();
         let path = bcast.path().clone();
-        let child_ref = ChildRef::new(id.clone(), sender.clone(), name.clone(), path);
+        let child_ref = ChildRef::new(id.clone(), sender.clone(), name, path);
 
         let children = self.as_ref();
         let supervisor = self.bcast.parent().clone().into_supervisor();
 
         let state = Arc::new(Mutex::new(Box::pin(ContextState::new())));
 
-        let ctx = BastionContext::new(
-            id.clone(),
-            child_ref.clone(),
-            children,
-            supervisor,
-            state.clone(),
-        );
+        let ctx = BastionContext::new(id, child_ref.clone(), children, supervisor, state.clone());
         let init = self.get_heartbeat_fut();
         let exec = (init.0)(ctx);
         self.bcast.register(&bcast);

--- a/src/bastion/src/children.rs
+++ b/src/bastion/src/children.rs
@@ -11,7 +11,7 @@ use crate::envelope::Envelope;
 use crate::message::BastionMessage;
 use crate::path::BastionPathElement;
 #[cfg(feature = "scaling")]
-use crate::resizer::{ActorGroupStats, Resizer, ScalingRule};
+use crate::resizer::{ActorGroupStats, OptimalSizeExploringResizer, ScalingRule};
 use crate::system::SYSTEM;
 use anyhow::Result as AnyResult;
 use async_mutex::Mutex;
@@ -95,7 +95,7 @@ pub struct Children {
     name: Option<String>,
     #[cfg(feature = "scaling")]
     // Resizer for dynamic actor group scaling up/down.
-    resizer: Box<Resizer>,
+    resizer: Box<OptimalSizeExploringResizer>,
 }
 
 impl Children {
@@ -108,10 +108,9 @@ impl Children {
         let pre_start_msgs = Vec::new();
         let started = false;
         let dispatchers = Vec::new();
-        #[cfg(feature = "scaling")]
-        let resizer = Box::new(Resizer::default());
         let name = None;
-        let resizer = Resizer::default();
+        #[cfg(feature = "scaling")]
+        let resizer = Box::new(OptimalSizeExploringResizer::default());
 
         Children {
             bcast,
@@ -358,9 +357,9 @@ impl Children {
     /// Bastion::children(|children| {
     ///     children
     ///         .with_resizer(
-    ///             Resizer::default()
+    ///             OptimalSizeExploringResizer::default()
     ///                 .with_lower_bound(10)
-    ///                 .with_upper_bound(UpperBoundLimit::Limit(100))
+    ///                 .with_upper_bound(UpperBound::Limit(100))
     ///         )
     /// }).expect("Couldn't create the children group.");
     ///     #
@@ -370,7 +369,7 @@ impl Children {
     /// # }
     /// ```
     /// [`Resizer`]: ../resizer/struct.Resizer.html
-    pub fn with_resizer(mut self, resizer: Resizer) -> Self {
+    pub fn with_resizer(mut self, resizer: OptimalSizeExploringResizer) -> Self {
         self.resizer = Box::new(resizer);
         self
     }

--- a/src/bastion/src/children.rs
+++ b/src/bastion/src/children.rs
@@ -98,7 +98,8 @@ pub struct Children {
     #[cfg(feature = "scaling")]
     // Resizer for dynamic actor group scaling up/down.
     resizer: Box<OptimalSizeExploringResizer>,
-    // Defines how ofter do heartbeat checks.
+    // Defines how often do heartbeat checks. By default checks will
+    // be done each 60 seconds.
     hearbeat_tick: Duration,
     // Special kind for actors that not going to be visible for others
     // parts of the cluster, but required for extra behaviour for the
@@ -120,7 +121,7 @@ impl Children {
         let name = None;
         #[cfg(feature = "scaling")]
         let resizer = Box::new(OptimalSizeExploringResizer::default());
-        let hearbeat_tick = Duration::from_secs(10);
+        let hearbeat_tick = Duration::from_secs(60);
         let helper_actors = FxHashMap::default();
 
         Children {
@@ -790,8 +791,6 @@ impl Children {
         let mut stats = ActorGroupStats::load(self.resizer.stats());
         stats.update_actors_count(self.launched.len() as u32);
         stats.store(self.resizer.stats());
-
-        println!("Active workers: {} [{}]", self.launched.len(), self.id());
     }
 
     #[cfg(feature = "scaling")]
@@ -815,8 +814,8 @@ impl Children {
 
     #[cfg(feature = "scaling")]
     fn init_data_for_scaling(&self, state: &mut ContextState) {
-        state.with_stats(self.resizer.stats());
-        state.with_actor_stats(self.resizer.actor_stats());
+        state.set_stats(self.resizer.stats());
+        state.set_actor_stats(self.resizer.actor_stats());
     }
 
     async fn run(mut self) -> Self {

--- a/src/bastion/src/context.rs
+++ b/src/bastion/src/context.rs
@@ -11,6 +11,8 @@ use crate::supervisor::SupervisorRef;
 use crate::system::SYSTEM;
 use async_mutex::Mutex;
 use futures::pending;
+#[cfg(feature = "scaling")]
+use lever::table::lotable::LOTable;
 use std::collections::VecDeque;
 use std::fmt::{self, Display, Formatter};
 use std::pin::Pin;
@@ -113,6 +115,8 @@ pub(crate) struct ContextState {
     messages: VecDeque<SignedMessage>,
     #[cfg(feature = "scaling")]
     stats: Arc<AtomicU64>,
+    #[cfg(feature = "scaling")]
+    actor_stats: Arc<LOTable<BastionId, u32>>,
 }
 
 impl BastionId {
@@ -575,18 +579,29 @@ impl ContextState {
             messages: VecDeque::new(),
             #[cfg(feature = "scaling")]
             stats: Arc::new(AtomicU64::new(0)),
+            #[cfg(feature = "scaling")]
+            actor_stats: Arc::new(LOTable::new()),
         }
     }
 
     #[cfg(feature = "scaling")]
-    pub(crate) fn with_stats(mut self, stats: Arc<AtomicU64>) -> Self {
+    pub(crate) fn with_stats(&mut self, stats: Arc<AtomicU64>) {
         self.stats = stats;
-        self
+    }
+
+    #[cfg(feature = "scaling")]
+    pub(crate) fn with_actor_stats(&mut self, actor_stats: Arc<LOTable<BastionId, u32>>) {
+        self.actor_stats = actor_stats;
     }
 
     #[cfg(feature = "scaling")]
     pub(crate) fn stats(&self) -> Arc<AtomicU64> {
         self.stats.clone()
+    }
+
+    #[cfg(feature = "scaling")]
+    pub(crate) fn actor_stats(&self) -> Arc<LOTable<BastionId, u32>> {
+        self.actor_stats.clone()
     }
 
     pub(crate) fn push_message(&mut self, msg: Msg, sign: RefAddr) {

--- a/src/bastion/src/context.rs
+++ b/src/bastion/src/context.rs
@@ -7,6 +7,7 @@ use crate::children_ref::ChildrenRef;
 use crate::dispatcher::{BroadcastTarget, DispatcherType, NotificationType};
 use crate::envelope::{Envelope, RefAddr, SignedMessage};
 use crate::message::{Answer, BastionMessage, Message, Msg};
+#[cfg(feature = "scaling")]
 use crate::resizer::ActorGroupStats;
 use crate::supervisor::SupervisorRef;
 use crate::system::SYSTEM;
@@ -15,6 +16,7 @@ use futures::pending;
 use std::collections::VecDeque;
 use std::fmt::{self, Display, Formatter};
 use std::pin::Pin;
+#[cfg(feature = "scaling")]
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use tracing::{debug, trace};
@@ -111,6 +113,7 @@ pub struct BastionContext {
 #[derive(Debug)]
 pub(crate) struct ContextState {
     messages: VecDeque<SignedMessage>,
+    #[cfg(feature = "scaling")]
     stats: Arc<AtomicU64>,
 }
 
@@ -572,6 +575,7 @@ impl ContextState {
     pub(crate) fn new() -> Self {
         ContextState {
             messages: VecDeque::new(),
+            #[cfg(feature = "scaling")]
             stats: Arc::new(AtomicU64::new(0)),
         }
     }
@@ -584,10 +588,12 @@ impl ContextState {
         self.messages.pop_front()
     }
 
+    #[cfg(feature = "scaling")]
     pub(crate) fn load_stats(&self) -> ActorGroupStats {
         ActorGroupStats::load(self.stats.clone())
     }
 
+    #[cfg(feature = "scaling")]
     pub(crate) fn store_stats(&self, stats: ActorGroupStats) {
         stats.store(self.stats.clone())
     }

--- a/src/bastion/src/context.rs
+++ b/src/bastion/src/context.rs
@@ -7,8 +7,6 @@ use crate::children_ref::ChildrenRef;
 use crate::dispatcher::{BroadcastTarget, DispatcherType, NotificationType};
 use crate::envelope::{Envelope, RefAddr, SignedMessage};
 use crate::message::{Answer, BastionMessage, Message, Msg};
-#[cfg(feature = "scaling")]
-use crate::resizer::ActorGroupStats;
 use crate::supervisor::SupervisorRef;
 use crate::system::SYSTEM;
 use async_mutex::Mutex;
@@ -586,6 +584,11 @@ impl ContextState {
         self
     }
 
+    #[cfg(feature = "scaling")]
+    pub(crate) fn stats(&self) -> Arc<AtomicU64> {
+        self.stats.clone()
+    }
+
     pub(crate) fn push_message(&mut self, msg: Msg, sign: RefAddr) {
         self.messages.push_back(SignedMessage::new(msg, sign))
     }
@@ -595,13 +598,8 @@ impl ContextState {
     }
 
     #[cfg(feature = "scaling")]
-    pub(crate) fn load_stats(&self) -> ActorGroupStats {
-        ActorGroupStats::load(self.stats.clone())
-    }
-
-    #[cfg(feature = "scaling")]
-    pub(crate) fn store_stats(&self, stats: ActorGroupStats) {
-        stats.store(self.stats.clone())
+    pub(crate) fn mailbox_size(&self) -> u32 {
+        self.messages.len() as u32
     }
 }
 

--- a/src/bastion/src/context.rs
+++ b/src/bastion/src/context.rs
@@ -7,6 +7,7 @@ use crate::children_ref::ChildrenRef;
 use crate::dispatcher::{BroadcastTarget, DispatcherType, NotificationType};
 use crate::envelope::{Envelope, RefAddr, SignedMessage};
 use crate::message::{Answer, BastionMessage, Message, Msg};
+use crate::resizer::ActorGroupStats;
 use crate::supervisor::SupervisorRef;
 use crate::system::SYSTEM;
 use async_mutex::Mutex;
@@ -14,6 +15,7 @@ use futures::pending;
 use std::collections::VecDeque;
 use std::fmt::{self, Display, Formatter};
 use std::pin::Pin;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use tracing::{debug, trace};
 use uuid::Uuid;
@@ -109,6 +111,7 @@ pub struct BastionContext {
 #[derive(Debug)]
 pub(crate) struct ContextState {
     messages: VecDeque<SignedMessage>,
+    stats: Arc<AtomicU64>,
 }
 
 impl BastionId {
@@ -569,6 +572,7 @@ impl ContextState {
     pub(crate) fn new() -> Self {
         ContextState {
             messages: VecDeque::new(),
+            stats: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -578,6 +582,14 @@ impl ContextState {
 
     pub(crate) fn pop_message(&mut self) -> Option<SignedMessage> {
         self.messages.pop_front()
+    }
+
+    pub(crate) fn load_stats(&self) -> ActorGroupStats {
+        ActorGroupStats::load(self.stats.clone())
+    }
+
+    pub(crate) fn store_stats(&self, stats: ActorGroupStats) {
+        stats.store(self.stats.clone())
     }
 }
 

--- a/src/bastion/src/context.rs
+++ b/src/bastion/src/context.rs
@@ -585,12 +585,12 @@ impl ContextState {
     }
 
     #[cfg(feature = "scaling")]
-    pub(crate) fn with_stats(&mut self, stats: Arc<AtomicU64>) {
+    pub(crate) fn set_stats(&mut self, stats: Arc<AtomicU64>) {
         self.stats = stats;
     }
 
     #[cfg(feature = "scaling")]
-    pub(crate) fn with_actor_stats(&mut self, actor_stats: Arc<LOTable<BastionId, u32>>) {
+    pub(crate) fn set_actor_stats(&mut self, actor_stats: Arc<LOTable<BastionId, u32>>) {
         self.actor_stats = actor_stats;
     }
 

--- a/src/bastion/src/context.rs
+++ b/src/bastion/src/context.rs
@@ -580,6 +580,12 @@ impl ContextState {
         }
     }
 
+    #[cfg(feature = "scaling")]
+    pub(crate) fn with_stats(mut self, stats: Arc<AtomicU64>) -> Self {
+        self.stats = stats;
+        self
+    }
+
     pub(crate) fn push_message(&mut self, msg: Msg, sign: RefAddr) {
         self.messages.push_back(SignedMessage::new(msg, sign))
     }

--- a/src/bastion/src/context.rs
+++ b/src/bastion/src/context.rs
@@ -614,7 +614,7 @@ impl ContextState {
 
     #[cfg(feature = "scaling")]
     pub(crate) fn mailbox_size(&self) -> u32 {
-        self.messages.len() as u32
+        self.messages.len() as _
     }
 }
 

--- a/src/bastion/src/dispatcher.rs
+++ b/src/bastion/src/dispatcher.rs
@@ -80,6 +80,10 @@ impl DispatcherHandler for RoundRobinHandler {
     }
     // Each child in turn will receive a message.
     fn broadcast_message(&self, entries: &DispatcherMap, message: &Arc<SignedMessage>) {
+        if entries.is_empty() {
+            return;
+        }
+
         let current_index = self.index.load(Ordering::SeqCst) % entries.len() as u64;
 
         let mut skipped = 0;

--- a/src/bastion/src/dispatcher.rs
+++ b/src/bastion/src/dispatcher.rs
@@ -80,7 +80,7 @@ impl DispatcherHandler for RoundRobinHandler {
     }
     // Each child in turn will receive a message.
     fn broadcast_message(&self, entries: &DispatcherMap, message: &Arc<SignedMessage>) {
-        if entries.is_empty() {
+        if entries.len() == 0 {
             return;
         }
 

--- a/src/bastion/src/lib.rs
+++ b/src/bastion/src/lib.rs
@@ -65,7 +65,6 @@ mod broadcast;
 mod callbacks;
 mod child;
 mod config;
-mod resizer;
 mod system;
 
 pub mod child_ref;
@@ -77,6 +76,7 @@ pub mod envelope;
 pub mod executor;
 pub mod message;
 pub mod path;
+pub mod resizer;
 pub mod supervisor;
 
 distributed_api! {
@@ -102,6 +102,7 @@ pub mod prelude {
     pub use crate::message::{Answer, AnswerSender, Message, Msg};
     pub use crate::msg;
     pub use crate::path::{BastionPath, BastionPathElement};
+    pub use crate::resizer::{Resizer, UpperBoundLimit, UpscaleStrategy};
     pub use crate::supervisor::{
         ActorRestartStrategy, RestartPolicy, RestartStrategy, SupervisionStrategy, Supervisor,
         SupervisorRef,

--- a/src/bastion/src/lib.rs
+++ b/src/bastion/src/lib.rs
@@ -65,6 +65,7 @@ mod broadcast;
 mod callbacks;
 mod child;
 mod config;
+mod resizer;
 mod system;
 
 pub mod child_ref;

--- a/src/bastion/src/lib.rs
+++ b/src/bastion/src/lib.rs
@@ -76,6 +76,7 @@ pub mod envelope;
 pub mod executor;
 pub mod message;
 pub mod path;
+#[cfg(feature = "scaling")]
 pub mod resizer;
 pub mod supervisor;
 

--- a/src/bastion/src/lib.rs
+++ b/src/bastion/src/lib.rs
@@ -102,7 +102,8 @@ pub mod prelude {
     pub use crate::message::{Answer, AnswerSender, Message, Msg};
     pub use crate::msg;
     pub use crate::path::{BastionPath, BastionPathElement};
-    pub use crate::resizer::{Resizer, UpperBoundLimit, UpscaleStrategy};
+    #[cfg(feature = "scaling")]
+    pub use crate::resizer::{Resizer, UpperBound, UpscaleStrategy};
     pub use crate::supervisor::{
         ActorRestartStrategy, RestartPolicy, RestartStrategy, SupervisionStrategy, Supervisor,
         SupervisorRef,

--- a/src/bastion/src/lib.rs
+++ b/src/bastion/src/lib.rs
@@ -103,7 +103,7 @@ pub mod prelude {
     pub use crate::msg;
     pub use crate::path::{BastionPath, BastionPathElement};
     #[cfg(feature = "scaling")]
-    pub use crate::resizer::{Resizer, UpperBound, UpscaleStrategy};
+    pub use crate::resizer::{OptimalSizeExploringResizer, UpperBound, UpscaleStrategy};
     pub use crate::supervisor::{
         ActorRestartStrategy, RestartPolicy, RestartStrategy, SupervisionStrategy, Supervisor,
         SupervisorRef,

--- a/src/bastion/src/message.rs
+++ b/src/bastion/src/message.rs
@@ -228,6 +228,7 @@ pub(crate) enum BastionMessage {
     Faulted {
         id: BastionId,
     },
+    Heartbeat,
 }
 
 #[derive(Debug)]
@@ -485,6 +486,10 @@ impl BastionMessage {
         BastionMessage::Faulted { id }
     }
 
+    pub(crate) fn heartbeat() -> Self {
+        BastionMessage::Heartbeat
+    }
+
     pub(crate) fn try_clone(&self) -> Option<Self> {
         trace!("{:?}: Trying to clone.", self);
         let clone = match self {
@@ -524,6 +529,7 @@ impl BastionMessage {
             BastionMessage::SetState { state } => BastionMessage::set_state(state.clone()),
             BastionMessage::Stopped { id } => BastionMessage::stopped(id.clone()),
             BastionMessage::Faulted { id } => BastionMessage::faulted(id.clone()),
+            BastionMessage::Heartbeat => BastionMessage::heartbeat(),
         };
 
         Some(clone)

--- a/src/bastion/src/message.rs
+++ b/src/bastion/src/message.rs
@@ -276,29 +276,17 @@ impl Msg {
 
     #[doc(hidden)]
     pub fn is_broadcast(&self) -> bool {
-        if let MsgInner::Broadcast(_) = self.0 {
-            true
-        } else {
-            false
-        }
+        matches!(self.0, MsgInner::Broadcast(_))
     }
 
     #[doc(hidden)]
     pub fn is_tell(&self) -> bool {
-        if let MsgInner::Tell(_) = self.0 {
-            true
-        } else {
-            false
-        }
+        matches!(self.0, MsgInner::Tell(_))
     }
 
     #[doc(hidden)]
     pub fn is_ask(&self) -> bool {
-        if let MsgInner::Ask { .. } = self.0 {
-            true
-        } else {
-            false
-        }
+        matches!(self.0, MsgInner::Ask { .. })
     }
 
     #[doc(hidden)]

--- a/src/bastion/src/path.rs
+++ b/src/bastion/src/path.rs
@@ -319,19 +319,13 @@ impl BastionPathElement {
     #[doc(hidden)]
     /// Checks whether the BastionPath identifies a supervisor.
     pub fn is_supervisor(&self) -> bool {
-        match self {
-            BastionPathElement::Supervisor(_) => true,
-            _ => false,
-        }
+        matches!(self, BastionPathElement::Supervisor(_))
     }
 
     #[doc(hidden)]
     /// Checks whether the BastionPath identifies children.
     pub fn is_children(&self) -> bool {
-        match self {
-            BastionPathElement::Children(_) => true,
-            _ => false,
-        }
+        matches!(self, BastionPathElement::Children(_))
     }
 
     /// Checks whether the BastionPath identifies a child.
@@ -361,10 +355,7 @@ impl BastionPathElement {
     /// # Bastion::block_until_stopped();
     /// ```
     pub fn is_child(&self) -> bool {
-        match self {
-            BastionPathElement::Child(_) => true,
-            _ => false,
-        }
+        matches!(self, BastionPathElement::Child(_))
     }
 }
 

--- a/src/bastion/src/resizer.rs
+++ b/src/bastion/src/resizer.rs
@@ -180,7 +180,7 @@ impl ActorGroupStats {
         let actors_count_mask = ActorGroupStats::actors_count_mask();
         let average_mailbox_size_mask = ActorGroupStats::average_mailbox_size_mask();
 
-        let value = storage.load(Ordering::Relaxed);
+        let value = storage.load(Ordering::SeqCst);
 
         ActorGroupStats {
             actors_count: ((value & actors_count_mask) >> 32) as u32,
@@ -197,7 +197,7 @@ impl ActorGroupStats {
         value |= (self.average_mailbox_size() as u64) & average_mailbox_size_mask;
         value |= ((self.actors_count() as u64) << 32) & actors_count_mask;
 
-        storage.store(value, Ordering::Relaxed);
+        storage.store(value, Ordering::SeqCst);
     }
 
     /// Returns an amount of active actors in the current group.

--- a/src/bastion/src/resizer.rs
+++ b/src/bastion/src/resizer.rs
@@ -143,7 +143,7 @@ impl OptimalSizeExploringResizer {
             UpscaleStrategy::MailboxSizeThreshold(threshold) => {
                 if stats.average_mailbox_size > threshold {
                     let count = stats.actors_count as f64 * self.downscale_threshold;
-                    return ScalingRule::Upscale(count.floor() as u64);
+                    return ScalingRule::Upscale(count.round() as u64);
                 }
             }
         };
@@ -217,7 +217,8 @@ impl ActorGroupStats {
 
     /// Updates the average mailbox size in the structure.
     pub(crate) fn update_average_mailbox_size(&mut self, value: u32) {
-        self.average_mailbox_size = (self.average_mailbox_size + value) / 2
+        let avg = (self.average_mailbox_size + value) as f32 / 2.0;
+        self.average_mailbox_size = avg.floor() as u32;
     }
 }
 

--- a/src/bastion/src/resizer.rs
+++ b/src/bastion/src/resizer.rs
@@ -137,12 +137,14 @@ impl OptimalSizeExploringResizer {
         &self,
         _actors: &FxHashMap<BastionId, (Sender, RecoverableHandle<()>)>,
     ) -> ScalingRule {
-        let stats = ActorGroupStats::load(self.stats.clone());
+        let mut stats = ActorGroupStats::load(self.stats.clone());
 
         match self.upscale_strategy {
             UpscaleStrategy::MailboxSizeThreshold(threshold) => {
                 if stats.average_mailbox_size > threshold {
                     let count = stats.actors_count as f64 * self.downscale_threshold;
+                    stats.average_mailbox_size = 0;
+                    stats.store(self.stats.clone());
                     return ScalingRule::Upscale(count.round() as u64);
                 }
             }

--- a/src/bastion/src/resizer.rs
+++ b/src/bastion/src/resizer.rs
@@ -1,0 +1,136 @@
+//!
+//! Special kind of structs for providing dynamically resizable actors group.
+//!
+//! Features:
+//! * Configuring limits and used strategies for resizers.
+//! * Strategy based on statistics given by spawned actors.
+//! * Auto-creation / deletion actors on demand.
+//!
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+/// Special struct for scaling up and down actor groups in runtime.
+pub struct Resizer {
+    // Storage for actors statistics.
+    stats: Arc<AtomicU64>,
+    // The minimal amount of actors that must be active.
+    lower_bound: u64,
+    // The maximal amount of actors acceptable for usage.
+    upper_bound: UpperBoundLimit,
+    // The usage strategy for scaling up actors in runtime.
+    upscale_strategy: UpscaleStrategy,
+    // Determines how much more actors needs to be created (in percentages
+    // relatively to the active actors).
+    upscale_rate: f64,
+    // The minimum percentage of busy actors before scaling down.
+    downscale_threshold: f64,
+    // Determines how much actors needs to be removed (in percentages
+    // relatively to the active actors).
+    downscale_rate: f64,
+}
+
+/// An enumeration that describe acceptable upper boundaries
+/// for the spawned actors in runtime.
+pub enum UpperBoundLimit {
+    /// Sets the limit for maximum available actors to use.   
+    Limit(u64),
+    /// No limits for spawning new actors.
+    Unlimited,
+}
+
+/// Determines the strategy for scaling up in runtime.
+pub enum UpscaleStrategy {
+    /// Scaling up based on how much of actors are busy.
+    ActorsAreBusy,
+    /// Scaling up based on how much actors are busy and have
+    /// accumulating messages in a mailbox.
+    ActorsUnderPressure,
+    /// Scaling up based on the size of the actor's mailbox.
+    MailboxSizeThreshold(u64),
+}
+
+impl Resizer {
+    /// Overrides the minimal amount of actors available to use.
+    pub fn with_lower_bound(mut self, lower_bound: u64) -> Self {
+        self.lower_bound = lower_bound;
+        self
+    }
+
+    /// Overrides the maximum amount of actors available to use.
+    pub fn with_upper_bound(mut self, upper_bound: UpperBoundLimit) -> Self {
+        self.upper_bound = upper_bound;
+        self
+    }
+
+    /// Overrides the upscale strategy to use.
+    pub fn with_upscale_strategy(mut self, upscale_strategy: UpscaleStrategy) -> Self {
+        self.upscale_strategy = upscale_strategy;
+        self
+    }
+
+    /// Overrides the upscale rate for actors.
+    pub fn with_upscale_rate(mut self, upscale_rate: f64) -> Self {
+        self.upscale_rate = upscale_rate;
+        self
+    }
+
+    /// Overrides the downscale threshold for resizer.
+    pub fn with_downscale_threshold(mut self, downscale_threshold: f64) -> Self {
+        self.downscale_threshold = downscale_threshold;
+        self
+    }
+
+    /// Overrides the downscale rate for actors.
+    pub fn with_downscale_rate(mut self, downscale_rate: f64) -> Self {
+        self.downscale_rate = downscale_rate;
+        self
+    }
+
+    /// Returns an atomic reference to data with actor statistics.
+    pub(crate) fn stats(&self) -> Arc<AtomicU64> {
+        self.stats.clone()
+    }
+
+    // TODO: Add implementation
+    pub(crate) fn get_actors_count(self) -> u64 {
+        0
+    }
+
+    // TODO: Add implementation
+    pub(crate) fn get_average_time_execution(self) -> u64 {
+        0
+    }
+
+    // TODO: Add implementation
+    pub(crate) fn get_average_mailbox_size(self) -> u64 {
+        0
+    }
+
+    // TODO: Add implementation
+    pub(crate) fn get_(self) -> u64 {
+        0
+    }
+
+    // TODO: Add implementation
+    pub(crate) fn get_median_mailbox_size(self) -> u64 {
+        0
+    }
+
+    /// Applies checks and does scaling up/down depends on stats.
+    /// TODO: Measure the execution time?
+    pub(crate) async fn scale(&self) {}
+}
+
+impl Default for Resizer {
+    fn default() -> Self {
+        Resizer {
+            stats: Arc::new(AtomicU64::new(0)),
+            lower_bound: 1,
+            upper_bound: UpperBoundLimit::Limit(10),
+            upscale_strategy: UpscaleStrategy::ActorsAreBusy,
+            upscale_rate: 0.2,
+            downscale_threshold: 0.3,
+            downscale_rate: 0.1,
+        }
+    }
+}

--- a/src/bastion/src/resizer.rs
+++ b/src/bastion/src/resizer.rs
@@ -15,6 +15,7 @@ use std::cmp::min;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+#[cfg(feature = "scaling")]
 #[derive(Debug)]
 /// Special struct for scaling up and down actor groups in runtime.
 pub struct OptimalSizeExploringResizer {
@@ -42,6 +43,7 @@ pub struct OptimalSizeExploringResizer {
     downscale_rate: f64,
 }
 
+#[cfg(feature = "scaling")]
 #[derive(Debug)]
 /// Special wrapper for Arc<AtomicU64> type, that actually
 /// represented as struct for storing statistical information
@@ -66,6 +68,7 @@ pub(crate) struct ActorGroupStats {
     average_mailbox_size: u32,
 }
 
+#[cfg(feature = "scaling")]
 #[derive(Debug, Clone)]
 /// An enumeration that describe acceptable upper boundaries
 /// for the spawned actors in runtime.
@@ -76,6 +79,7 @@ pub enum UpperBound {
     Unlimited,
 }
 
+#[cfg(feature = "scaling")]
 #[derive(Debug, Clone)]
 /// Determines the strategy for scaling up in runtime.
 pub enum UpscaleStrategy {
@@ -83,6 +87,7 @@ pub enum UpscaleStrategy {
     MailboxSizeThreshold(u32),
 }
 
+#[cfg(feature = "scaling")]
 #[derive(Debug)]
 /// Determines what action needs to be applied by the caller
 /// after Resizer checks.
@@ -95,6 +100,7 @@ pub(crate) enum ScalingRule {
     DoNothing,
 }
 
+#[cfg(feature = "scaling")]
 impl OptimalSizeExploringResizer {
     /// Returns an atomic reference to data with actor statistics.
     pub(crate) fn stats(&self) -> Arc<AtomicU64> {
@@ -255,6 +261,7 @@ impl OptimalSizeExploringResizer {
     }
 }
 
+#[cfg(feature = "scaling")]
 impl Default for OptimalSizeExploringResizer {
     fn default() -> Self {
         OptimalSizeExploringResizer {
@@ -270,6 +277,7 @@ impl Default for OptimalSizeExploringResizer {
     }
 }
 
+#[cfg(feature = "scaling")]
 impl ActorGroupStats {
     fn actors_count_mask() -> u64 {
         0xFFFFFFFF_00000000

--- a/src/bastion/src/resizer.rs
+++ b/src/bastion/src/resizer.rs
@@ -166,7 +166,7 @@ impl OptimalSizeExploringResizer {
         for (actor_id, (_, handle)) in actors {
             let state = handle.state();
             let mailbox_size = self.actor_stats.get(actor_id).unwrap_or(0);
-            let can_be_freed = state.is_pending() && mailbox_size == 0;
+            let can_be_freed = mailbox_size == 0 && state.is_pending();
 
             if state.is_closed() || state.is_completed() || can_be_freed {
                 actors_to_stop.push(actor_id.clone())
@@ -225,7 +225,7 @@ impl Default for OptimalSizeExploringResizer {
         OptimalSizeExploringResizer {
             stats: Arc::new(AtomicU64::new(0)),
             actor_stats: Arc::new(LOTable::new()),
-            lower_bound: 1,
+            lower_bound: 0,
             upper_bound: UpperBound::Limit(10),
             upscale_strategy: UpscaleStrategy::MailboxSizeThreshold(3),
             upscale_rate: 0.1,

--- a/src/bastion/src/resizer.rs
+++ b/src/bastion/src/resizer.rs
@@ -1,5 +1,5 @@
 //!
-//! Special kind of structs for providing dynamically resizable actors group.
+//! Special kind of structs for resizable actor groups in runtime.
 //!
 //! Features:
 //! * Configuring limits and used strategies for resizers.

--- a/src/bastion/src/resizer.rs
+++ b/src/bastion/src/resizer.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 #[derive(Debug)]
 /// Special struct for scaling up and down actor groups in runtime.
-pub struct Resizer {
+pub struct OptimalSizeExploringResizer {
     // Storage for actors statistics. The statistics struct is
     // represented as a sequence of bits stored in u64 value with
     // the big-endian endianness. Currently stores the amount of
@@ -90,7 +90,7 @@ pub(crate) enum ScalingRule {
     DoNothing,
 }
 
-impl Resizer {
+impl OptimalSizeExploringResizer {
     /// Returns an atomic reference to data with actor statistics.
     pub(crate) fn stats(&self) -> Arc<AtomicU64> {
         self.stats.clone()
@@ -152,9 +152,9 @@ impl Resizer {
     }
 }
 
-impl Default for Resizer {
+impl Default for OptimalSizeExploringResizer {
     fn default() -> Self {
-        Resizer {
+        OptimalSizeExploringResizer {
             stats: Arc::new(AtomicU64::new(0)),
             lower_bound: 1,
             upper_bound: UpperBound::Limit(10),
@@ -223,11 +223,11 @@ impl ActorGroupStats {
 
 #[cfg(test)]
 mod tests {
-    use crate::resizer::{ActorGroupStats, Resizer};
+    use crate::resizer::{ActorGroupStats, OptimalSizeExploringResizer};
 
     #[test]
     fn test_resizer_stores_empty_stats_by_default() {
-        let resizer = Resizer::default();
+        let resizer = OptimalSizeExploringResizer::default();
 
         let stats = ActorGroupStats::load(resizer.stats);
         assert_eq!(stats.actors_count, 0);
@@ -236,7 +236,7 @@ mod tests {
 
     #[test]
     fn test_resizer_returns_refreshed_stats_after_actors_count_update() {
-        let resizer = Resizer::default();
+        let resizer = OptimalSizeExploringResizer::default();
         let atomic_stats = resizer.stats();
 
         let mut stats = ActorGroupStats::load(atomic_stats.clone());
@@ -250,7 +250,7 @@ mod tests {
 
     #[test]
     fn test_resizer_returns_refreshed_stats_after_avg_mailbox_size_update() {
-        let resizer = Resizer::default();
+        let resizer = OptimalSizeExploringResizer::default();
         let atomic_stats = resizer.stats();
 
         let mut stats = ActorGroupStats::load(atomic_stats.clone());
@@ -264,7 +264,7 @@ mod tests {
 
     #[test]
     fn test_resizer_returns_refreshed_stats_after_actor_count_and_avg_mailbox_size_update() {
-        let resizer = Resizer::default();
+        let resizer = OptimalSizeExploringResizer::default();
         let atomic_stats = resizer.stats();
 
         let mut stats = ActorGroupStats::load(atomic_stats.clone());

--- a/src/bastion/src/resizer.rs
+++ b/src/bastion/src/resizer.rs
@@ -205,10 +205,13 @@ impl OptimalSizeExploringResizer {
         let mut actors_to_stop = Vec::new();
         for (actor_id, (_, handle)) in actors {
             let state = handle.state();
-            let mailbox_size = self.actor_stats.get(actor_id).unwrap_or(0);
-            let can_be_freed = mailbox_size == 0 && state.is_pending();
 
-            if state.is_closed() || state.is_completed() || can_be_freed {
+            // TODO: Enable the following this check when the following will be resolved
+            // link: https://github.com/bastion-rs/bastion/issues/236
+            // let mailbox_size = self.actor_stats.get(actor_id).unwrap_or(0);
+            // let can_be_freed = mailbox_size == 0 && state.is_pending();
+
+            if state.is_closed() || state.is_completed() {
                 actors_to_stop.push(actor_id.clone())
             }
         }

--- a/src/bastion/src/resizer.rs
+++ b/src/bastion/src/resizer.rs
@@ -206,7 +206,7 @@ impl OptimalSizeExploringResizer {
         for (actor_id, (_, handle)) in actors {
             let state = handle.state();
 
-            // TODO: Enable the following this check when the following will be resolved
+            // TODO: Enable this check when the following issue will be resolved
             // link: https://github.com/bastion-rs/bastion/issues/236
             // let mailbox_size = self.actor_stats.get(actor_id).unwrap_or(0);
             // let can_be_freed = mailbox_size == 0 && state.is_pending();

--- a/src/bastion/src/resizer.rs
+++ b/src/bastion/src/resizer.rs
@@ -20,7 +20,7 @@ pub struct Resizer {
     // The minimal amount of actors that must be active.
     lower_bound: u64,
     // The maximal amount of actors acceptable for usage.
-    upper_bound: UpperBoundLimit,
+    upper_bound: UpperBound,
     // The usage strategy for scaling up actors in runtime.
     upscale_strategy: UpscaleStrategy,
     // Determines how much more actors needs to be created (in percentages
@@ -60,7 +60,7 @@ pub(crate) struct ActorGroupStats {
 #[derive(Debug)]
 /// An enumeration that describe acceptable upper boundaries
 /// for the spawned actors in runtime.
-pub enum UpperBoundLimit {
+pub enum UpperBound {
     /// Sets the limit for maximum available actors to use.   
     Limit(u64),
     /// No limits for spawning new actors.
@@ -92,7 +92,7 @@ impl Resizer {
     }
 
     /// Overrides the maximum amount of actors available to use.
-    pub fn with_upper_bound(mut self, upper_bound: UpperBoundLimit) -> Self {
+    pub fn with_upper_bound(mut self, upper_bound: UpperBound) -> Self {
         self.upper_bound = upper_bound;
         self
     }
@@ -136,7 +136,7 @@ impl Default for Resizer {
         Resizer {
             stats: Arc::new(AtomicU64::new(0)),
             lower_bound: 1,
-            upper_bound: UpperBoundLimit::Limit(10),
+            upper_bound: UpperBound::Limit(10),
             upscale_strategy: UpscaleStrategy::MailboxSizeThreshold(3),
             upscale_rate: 0.1,
             downscale_threshold: 0.3,

--- a/src/bastion/src/resizer.rs
+++ b/src/bastion/src/resizer.rs
@@ -6,12 +6,15 @@
 //! * Strategy based on statistics given by spawned actors.
 //! * Auto-creation / deletion actors on demand.
 //!
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 /// Special struct for scaling up and down actor groups in runtime.
 pub struct Resizer {
-    // Storage for actors statistics.
+    // Storage for actors statistics. The statistics struct is
+    // represented as a sequence of bits stored in u64 value with
+    // the big-endian endianness. Currently stores the amount of
+    // active actors and an average mailbox size for the actor group.
     stats: Arc<AtomicU64>,
     // The minimal amount of actors that must be active.
     lower_bound: u64,
@@ -29,6 +32,29 @@ pub struct Resizer {
     downscale_rate: f64,
 }
 
+/// Special wrapper for Arc<AtomicU64> type, that actually
+/// represented as struct for storing statistical information
+/// about the certain actor group.
+///
+/// This structure helps to provide an elegant way for handling
+/// data as a sequence of bits/bytes and improve readability
+/// in many places, where it supposed to be used.
+///
+/// The binary representation this struct for Arc<AtomicU64> can
+/// be represented in the following way:
+///
+/// |                        AtomicU64                        |  
+/// |<----------------------- 64 bits ----------------------->|
+/// |                                                         |                             
+/// |                    ActorGroupStats                      |
+/// |<------- 32 bits ---------->|<------- 32 bits ---------->|
+/// |       actors_count         |    average_mailbox_size    |
+///
+pub(crate) struct ActorGroupStats {
+    actors_count: u32,
+    average_mailbox_size: u32,
+}
+
 /// An enumeration that describe acceptable upper boundaries
 /// for the spawned actors in runtime.
 pub enum UpperBoundLimit {
@@ -42,11 +68,13 @@ pub enum UpperBoundLimit {
 pub enum UpscaleStrategy {
     /// Scaling up based on how much of actors are busy.
     ActorsAreBusy,
-    /// Scaling up based on how much actors are busy and have
-    /// accumulating messages in a mailbox.
+    /// Scaling up based on how many actors are busy and
+    /// have accumulating messages in a mailbox. If actor
+    /// is busy and has more message than the limit, then
+    /// needs to consider re-scaling.
     ActorsUnderPressure,
     /// Scaling up based on the size of the actor's mailbox.
-    MailboxSizeThreshold(u64),
+    MailboxSizeThreshold(u32),
 }
 
 impl Resizer {
@@ -91,31 +119,6 @@ impl Resizer {
         self.stats.clone()
     }
 
-    // TODO: Add implementation
-    pub(crate) fn get_actors_count(self) -> u64 {
-        0
-    }
-
-    // TODO: Add implementation
-    pub(crate) fn get_average_time_execution(self) -> u64 {
-        0
-    }
-
-    // TODO: Add implementation
-    pub(crate) fn get_average_mailbox_size(self) -> u64 {
-        0
-    }
-
-    // TODO: Add implementation
-    pub(crate) fn get_(self) -> u64 {
-        0
-    }
-
-    // TODO: Add implementation
-    pub(crate) fn get_median_mailbox_size(self) -> u64 {
-        0
-    }
-
     /// Applies checks and does scaling up/down depends on stats.
     /// TODO: Measure the execution time?
     pub(crate) async fn scale(&self) {}
@@ -128,9 +131,67 @@ impl Default for Resizer {
             lower_bound: 1,
             upper_bound: UpperBoundLimit::Limit(10),
             upscale_strategy: UpscaleStrategy::ActorsAreBusy,
-            upscale_rate: 0.2,
+            upscale_rate: 0.1,
             downscale_threshold: 0.3,
             downscale_rate: 0.1,
         }
     }
 }
+
+impl ActorGroupStats {
+    fn actors_count_mask() -> u64 {
+        0xFFFFFFFF_00000000
+    }
+
+    fn average_mailbox_size_mask() -> u64 {
+        0x00000000_FFFFFFFF
+    }
+
+    /// Extract statistics from Arc<AtomicU64>
+    pub(crate) fn load(storage: Arc<AtomicU64>) -> Self {
+        let actors_count_mask = ActorGroupStats::actors_count_mask();
+        let average_mailbox_size_mask = ActorGroupStats::average_mailbox_size_mask();
+
+        let value = storage.load(Ordering::Relaxed);
+
+        ActorGroupStats {
+            actors_count: ((value & actors_count_mask) >> 32) as u32,
+            average_mailbox_size: (value & average_mailbox_size_mask) as u32,
+        }
+    }
+
+    /// Write the changes in Arc<AtomicU64>
+    pub(crate) fn store(&self, storage: Arc<AtomicU64>) {
+        let actors_count_mask = ActorGroupStats::actors_count_mask();
+        let average_mailbox_size_mask = ActorGroupStats::average_mailbox_size_mask();
+
+        let mut value: u64 = 0;
+        value |= ((self.average_mailbox_size() as u64) & actors_count_mask);
+        value |= ((self.actors_count() as u64) & actors_count_mask) << 32;
+
+        storage.store(value, Ordering::Relaxed);
+    }
+
+    /// Returns an amount of active actors in the current group.
+    pub(crate) fn actors_count(&self) -> u32 {
+        self.actors_count
+    }
+
+    /// Updates the actors count value in the structure.
+    pub(crate) fn update_actors_count(&mut self, value: u32) {
+        self.actors_count = value
+    }
+
+    /// Returns current average mailbox size for the actors group.
+    pub(crate) fn average_mailbox_size(&self) -> u32 {
+        self.average_mailbox_size
+    }
+
+    /// Updates the average mailbox size in the structure.
+    pub(crate) fn update_average_mailbox_size(&mut self, value: u32) {
+        self.average_mailbox_size = (self.average_mailbox_size + value) / 2
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/src/bastion/src/resizer.rs
+++ b/src/bastion/src/resizer.rs
@@ -9,6 +9,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+#[derive(Debug)]
 /// Special struct for scaling up and down actor groups in runtime.
 pub struct Resizer {
     // Storage for actors statistics. The statistics struct is
@@ -32,6 +33,7 @@ pub struct Resizer {
     downscale_rate: f64,
 }
 
+#[derive(Debug)]
 /// Special wrapper for Arc<AtomicU64> type, that actually
 /// represented as struct for storing statistical information
 /// about the certain actor group.
@@ -55,6 +57,7 @@ pub(crate) struct ActorGroupStats {
     average_mailbox_size: u32,
 }
 
+#[derive(Debug)]
 /// An enumeration that describe acceptable upper boundaries
 /// for the spawned actors in runtime.
 pub enum UpperBoundLimit {
@@ -64,20 +67,18 @@ pub enum UpperBoundLimit {
     Unlimited,
 }
 
+#[derive(Debug)]
 /// Determines the strategy for scaling up in runtime.
 pub enum UpscaleStrategy {
-    /// Scaling up based on how much of actors are busy.
-    ActorsAreBusy,
-    /// Scaling up based on how many actors are busy and
-    /// have accumulating messages in a mailbox. If actor
-    /// is busy and has more message than the limit, then
-    /// needs to consider re-scaling.
-    ActorsUnderPressure,
     /// Scaling up based on the size of the actor's mailbox.
     MailboxSizeThreshold(u32),
 }
 
 impl Resizer {
+    pub(crate) fn set_lower_bound(&mut self, lower_bound: u64) {
+        self.lower_bound = lower_bound
+    }
+
     /// Overrides the minimal amount of actors available to use.
     pub fn with_lower_bound(mut self, lower_bound: u64) -> Self {
         self.lower_bound = lower_bound;
@@ -130,7 +131,7 @@ impl Default for Resizer {
             stats: Arc::new(AtomicU64::new(0)),
             lower_bound: 1,
             upper_bound: UpperBoundLimit::Limit(10),
-            upscale_strategy: UpscaleStrategy::ActorsAreBusy,
+            upscale_strategy: UpscaleStrategy::MailboxSizeThreshold(3),
             upscale_rate: 0.1,
             downscale_threshold: 0.3,
             downscale_rate: 0.1,

--- a/src/bastion/src/resizer.rs
+++ b/src/bastion/src/resizer.rs
@@ -75,6 +75,12 @@ pub enum UpscaleStrategy {
 }
 
 impl Resizer {
+    /// Return the lower bound (the minimal amount of actors).
+    pub(crate) fn lower_bound(&self) -> u64 {
+        self.lower_bound
+    }
+
+    /// Overrides the lower bound,
     pub(crate) fn set_lower_bound(&mut self, lower_bound: u64) {
         self.lower_bound = lower_bound
     }
@@ -148,7 +154,7 @@ impl ActorGroupStats {
         0x00000000_FFFFFFFF
     }
 
-    /// Extract statistics from Arc<AtomicU64>
+    /// Extract statistics from Arc<AtomicU64>.
     pub(crate) fn load(storage: Arc<AtomicU64>) -> Self {
         let actors_count_mask = ActorGroupStats::actors_count_mask();
         let average_mailbox_size_mask = ActorGroupStats::average_mailbox_size_mask();
@@ -161,7 +167,7 @@ impl ActorGroupStats {
         }
     }
 
-    /// Write the changes in Arc<AtomicU64>
+    /// Write the changes in Arc<AtomicU64>.
     pub(crate) fn store(&self, storage: Arc<AtomicU64>) {
         let actors_count_mask = ActorGroupStats::actors_count_mask();
         let average_mailbox_size_mask = ActorGroupStats::average_mailbox_size_mask();

--- a/src/bastion/src/supervisor.rs
+++ b/src/bastion/src/supervisor.rs
@@ -1315,8 +1315,6 @@ impl Supervisor {
     async fn run(mut self) -> Self {
         debug!("Supervisor({}): Launched.", self.id());
         loop {
-            self.resizer.scale();
-
             match poll!(&mut self.bcast.next()) {
                 // TODO: Err if started == true?
                 Poll::Ready(Some(Envelope {
@@ -1351,8 +1349,6 @@ impl Supervisor {
                 Poll::Ready(None) => unreachable!(),
                 Poll::Pending => pending!(),
             }
-
-            self.resizer.scale();
         }
     }
 

--- a/src/bastion/src/supervisor.rs
+++ b/src/bastion/src/supervisor.rs
@@ -1277,6 +1277,10 @@ impl Supervisor {
                 msg: BastionMessage::Faulted { id },
                 ..
             } => self.cleanup_supervised_object(id).await,
+            Envelope {
+                msg: BastionMessage::Heartbeat,
+                ..
+            } => unreachable!(),
         }
 
         Ok(())

--- a/src/bastion/src/supervisor.rs
+++ b/src/bastion/src/supervisor.rs
@@ -1315,6 +1315,8 @@ impl Supervisor {
     async fn run(mut self) -> Self {
         debug!("Supervisor({}): Launched.", self.id());
         loop {
+            self.resizer.scale();
+
             match poll!(&mut self.bcast.next()) {
                 // TODO: Err if started == true?
                 Poll::Ready(Some(Envelope {
@@ -1349,6 +1351,8 @@ impl Supervisor {
                 Poll::Ready(None) => unreachable!(),
                 Poll::Pending => pending!(),
             }
+
+            self.resizer.scale();
         }
     }
 

--- a/src/bastion/src/system.rs
+++ b/src/bastion/src/system.rs
@@ -377,6 +377,10 @@ impl System {
                 msg: BastionMessage::Faulted { id, .. },
                 ..
             } => self.restart_supervised_object(id),
+            Envelope {
+                msg: BastionMessage::Heartbeat,
+                ..
+            } => unreachable!(),
         }
 
         Ok(())

--- a/src/lightproc/src/proc_handle.rs
+++ b/src/lightproc/src/proc_handle.rs
@@ -94,6 +94,14 @@ impl<R> ProcHandle<R> {
             &*raw
         }
     }
+
+    /// Returns current state of the handle.
+    pub fn state(&self) -> State {
+        let ptr = self.raw_proc.as_ptr();
+        let pdata = ptr as *const ProcData;
+        let raw_state = unsafe { (*pdata).state.load(Ordering::SeqCst) };
+        State::new(raw_state)
+    }
 }
 
 impl<R> Future for ProcHandle<R> {

--- a/src/lightproc/src/recoverable_handle.rs
+++ b/src/lightproc/src/recoverable_handle.rs
@@ -3,6 +3,7 @@
 use crate::proc_data::ProcData;
 use crate::proc_handle::ProcHandle;
 use crate::proc_stack::ProcStack;
+use crate::state::State;
 use std::fmt::{self, Debug, Formatter};
 use std::future::Future;
 use std::pin::Pin;
@@ -27,6 +28,11 @@ impl<R> RecoverableHandle<R> {
     /// Returns a reference to the stack stored inside the proc.
     pub fn stack(&self) -> &ProcStack {
         self.0.stack()
+    }
+
+    /// Returns a state of the ProcHandle.
+    pub fn state(&self) -> State {
+        self.0.state()
     }
 }
 

--- a/src/lightproc/src/state.rs
+++ b/src/lightproc/src/state.rs
@@ -107,6 +107,11 @@ impl State {
     pub fn is_locked(&self) -> bool {
         self.0 & LOCKED != 0
     }
+
+    /// Returns `true` if the future is in the pending.
+    pub fn is_pending(&self) -> bool {
+        self.0 & COMPLETED == 0
+    }
 }
 
 #[cfg(test)]
@@ -195,5 +200,17 @@ mod tests {
     fn test_is_locked_returns_false() {
         let state = State::new(0);
         assert_eq!(state.is_locked(), false);
+    }
+
+    #[test]
+    fn test_is_pending_returns_true() {
+        let state = State::new(0);
+        assert_eq!(state.is_pending(), true);
+    }
+
+    #[test]
+    fn test_is_pending_returns_false() {
+        let state = State::new(COMPLETED);
+        assert_eq!(state.is_pending(), false);
     }
 }

--- a/src/lightproc/src/state.rs
+++ b/src/lightproc/src/state.rs
@@ -63,3 +63,137 @@ pub(crate) const LOCKED: usize = 1 << 6;
 /// Note that the reference counter only tracks the `LightProc` and `Waker`s. The `ProcHandle` is
 /// tracked separately by the `HANDLE` flag.
 pub(crate) const REFERENCE: usize = 1 << 7;
+
+/// Human-readable representation of the ProcHandle state;
+#[derive(Debug)]
+pub struct State(usize);
+
+impl State {
+    pub fn new(value: usize) -> Self {
+        State(value)
+    }
+
+    /// Returns `true` if the proc is scheduled for running.
+    pub fn is_scheduled(&self) -> bool {
+        self.0 & SCHEDULED != 0
+    }
+
+    /// Returns `true` if a proc is running state while its future is being polled.
+    pub fn is_running(&self) -> bool {
+        self.0 & RUNNING != 0
+    }
+
+    /// Returns `true` if the proc has been completed.
+    pub fn is_completed(&self) -> bool {
+        self.0 & COMPLETED != 0
+    }
+
+    /// Returns `true` if the proc is closed or has panicked.
+    pub fn is_closed(&self) -> bool {
+        self.0 & CLOSED != 0
+    }
+
+    /// Returns `true` if the `ProcHandle` still exists.
+    pub fn is_handle(&self) -> bool {
+        self.0 & HANDLE != 0
+    }
+
+    /// Returns `true` if the awaiter is locked.
+    pub fn is_awaiter(&self) -> bool {
+        self.0 & AWAITER != 0
+    }
+
+    /// Returns `true` if the awaiter is locked.
+    pub fn is_locked(&self) -> bool {
+        self.0 & LOCKED != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::state::*;
+
+    #[test]
+    fn test_is_scheduled_returns_true() {
+        let state = State::new(SCHEDULED);
+        assert_eq!(state.is_scheduled(), true);
+    }
+
+    #[test]
+    fn test_is_scheduled_returns_false() {
+        let state = State::new(0);
+        assert_eq!(state.is_scheduled(), false);
+    }
+
+    #[test]
+    fn test_is_running_returns_true() {
+        let state = State::new(RUNNING);
+        assert_eq!(state.is_running(), true);
+    }
+
+    #[test]
+    fn test_is_running_returns_false() {
+        let state = State::new(0);
+        assert_eq!(state.is_running(), false);
+    }
+
+    #[test]
+    fn test_is_completed_returns_true() {
+        let state = State::new(COMPLETED);
+        assert_eq!(state.is_completed(), true);
+    }
+
+    #[test]
+    fn test_is_completed_returns_false() {
+        let state = State::new(0);
+        assert_eq!(state.is_completed(), false);
+    }
+
+    #[test]
+    fn test_is_closed_returns_true() {
+        let state = State::new(CLOSED);
+        assert_eq!(state.is_closed(), true);
+    }
+
+    #[test]
+    fn test_is_closed_returns_false() {
+        let state = State::new(0);
+        assert_eq!(state.is_closed(), false);
+    }
+
+    #[test]
+    fn test_is_handle_returns_true() {
+        let state = State::new(HANDLE);
+        assert_eq!(state.is_handle(), true);
+    }
+
+    #[test]
+    fn test_is_handle_returns_false() {
+        let state = State::new(0);
+        assert_eq!(state.is_handle(), false);
+    }
+
+    #[test]
+    fn test_is_awaiter_returns_true() {
+        let state = State::new(AWAITER);
+        assert_eq!(state.is_awaiter(), true);
+    }
+
+    #[test]
+    fn test_is_awaiter_returns_false() {
+        let state = State::new(0);
+        assert_eq!(state.is_awaiter(), false);
+    }
+
+    #[test]
+    fn test_is_locked_returns_true() {
+        let state = State::new(LOCKED);
+        assert_eq!(state.is_locked(), true);
+    }
+
+    #[test]
+    fn test_is_locked_returns_false() {
+        let state = State::new(0);
+        assert_eq!(state.is_locked(), false);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bastion-rs/.github/blob/master/CONTRIBUTING.md
-->
As the part of this PR, I would to introduce the changes that cover needs in autoscaling actor groups in runtime. The initiative was described in the #155 issue.

##### The idea 
Before starting with the example, any developers needs to enable the `scaling` feature flag which using for getting an access to desired API, collecting statistical information from actors, etc.

Then, we can import the resizer, and declare the rules around how much actors acceptable (minimal, maximum) for the each actor group. It will be look something like this:
```rust
children
    .with_redundancy(3)                                // Start with 3 actors
    .with_resizer(
        Resizer::default()
            .with_lower_bound(0)                       // A minimal acceptable size of group
            .with_upper_bound(UpperBound::Limit(10))   // Max 10 actors in runtime
            .with_upscale_strategy(UpscaleStrategy::MailboxSizeThreshold(3)) // Scale up when a half of actors have more then 3 messages
            .with_upscale_rate(0.1)                    // Increase the size of group on 10%, if necessary to scale up
            .with_downscale_rate(0.2)                  // Decrease the size of group on 20%, if too many free actors
    )
```

The resizers will take care about reacting on collected stats (currently: active actors and the average mailbox size) and will ask a Child instance to scale up or down the actor group when it necessary in runtime.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] added example
- [x] tests are passing with `cargo test`. 
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message is clear

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
