### PR TITLE
[Refactor] Explicit initialization for SYSTEM

### DIFF
--- a/src/bastion/src/bastion.rs
+++ b/src/bastion/src/bastion.rs
@@ -218,8 +218,7 @@ impl Bastion {
             std::panic::set_hook(Box::new(|_| ()));
         }
 
-        // NOTE: this is just to make sure that SYSTEM has been initialized by lazy_static
-        SYSTEM.sender().is_closed();
+        lazy_static::initialize(&SYSTEM);
     }
 
     /// Creates a new [`Supervisor`], passes it through the specified


### PR DESCRIPTION
Use explicitly lazy_static::initialize to trigger initialization instead of calling a method on the lazy value.

Minor thing I noticed while reading through :grin: 