### PR TITLE
Self-contained macros

### DIFF
--- a/src/bastion/src/executor.rs
+++ b/src/bastion/src/executor.rs
@@ -1,0 +1,27 @@
+//! A module that exposes the functions used under the hoods from `bastion`s macros: `spawn!`, `run!`
+//! and `blocking!`.
+pub use lightproc::proc_stack::ProcStack;
+use std::future::Future;
+use lightproc::recoverable_handle::RecoverableHandle;
+
+/// Spawns a blocking task, which will run on the blocking thread pool,
+/// and returns the handle.
+///
+/// # Example
+/// ```
+/// # use std::{thread, time};
+/// # use bastion::executor::blocking;
+/// # fn main() {
+/// let task = blocking(async move {
+///     thread::sleep(time::Duration::from_millis(3000));
+/// });
+/// # }
+/// ```
+pub fn blocking<F, R>(future: F) -> RecoverableHandle<R> where
+    F: Future<Output = R> + Send + 'static,
+    R: Send + 'static
+{
+    bastion_executor::blocking::spawn_blocking(future, lightproc::proc_stack::ProcStack::default())
+}
+
+

--- a/src/bastion/src/executor.rs
+++ b/src/bastion/src/executor.rs
@@ -1,8 +1,8 @@
 //! A module that exposes the functions used under the hoods from `bastion`s macros: `spawn!`, `run!`
 //! and `blocking!`.
 pub use lightproc::proc_stack::ProcStack;
-use std::future::Future;
 use lightproc::recoverable_handle::RecoverableHandle;
+use std::future::Future;
 
 /// Spawns a blocking task, which will run on the blocking thread pool,
 /// and returns the handle.
@@ -10,18 +10,70 @@ use lightproc::recoverable_handle::RecoverableHandle;
 /// # Example
 /// ```
 /// # use std::{thread, time};
-/// # use bastion::executor::blocking;
+/// use bastion::executor::blocking;
 /// # fn main() {
 /// let task = blocking(async move {
 ///     thread::sleep(time::Duration::from_millis(3000));
 /// });
 /// # }
 /// ```
-pub fn blocking<F, R>(future: F) -> RecoverableHandle<R> where
+pub fn blocking<F, R>(future: F) -> RecoverableHandle<R>
+where
     F: Future<Output = R> + Send + 'static,
-    R: Send + 'static
+    R: Send + 'static,
 {
     bastion_executor::blocking::spawn_blocking(future, lightproc::proc_stack::ProcStack::default())
 }
 
+/// Block the current thread until passed
+/// future is resolved with an output (including the panic).
+///
+/// # Example
+/// ```
+/// # use bastion::prelude::*;
+/// use bastion::executor::run;
+/// # fn main() {
+/// let future1 = async move {
+///     123
+/// };
+///
+/// run(async move {
+///     let result = future1.await;
+///     assert_eq!(result, 123);
+/// });
+///
+/// let future2 = async move {
+///     10 / 2
+/// };
+///
+/// let result = run(future2);
+/// assert_eq!(result, 5);
+/// # }
+/// ```
+pub fn run<F, T>(future: F) -> T
+where
+    F: Future<Output = T>,
+{
+    bastion_executor::run::run(future, lightproc::proc_stack::ProcStack::default())
+}
 
+/// Spawn a given future onto the executor from the global level.
+///
+/// # Example
+/// ```
+/// # use bastion::prelude::*;
+/// use bastion::executor::{spawn, run};
+/// # fn main() {
+/// let handle = spawn(async {
+///     panic!("test");
+/// });
+/// run(handle);
+/// # }
+/// ```
+pub fn spawn<F, T>(future: F) -> RecoverableHandle<T>
+where
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    bastion_executor::pool::spawn(future, lightproc::proc_stack::ProcStack::default())
+}

--- a/src/bastion/src/lib.rs
+++ b/src/bastion/src/lib.rs
@@ -77,6 +77,7 @@ pub mod children_ref;
 pub mod context;
 pub mod dispatcher;
 pub mod envelope;
+pub mod executor;
 pub mod message;
 pub mod path;
 pub mod supervisor;

--- a/src/bastion/src/macros.rs
+++ b/src/bastion/src/macros.rs
@@ -199,9 +199,9 @@ macro_rules! supervisor {
 #[macro_export]
 macro_rules! blocking {
     ($($tokens:tt)*) => {
-        bastion_executor::blocking::spawn_blocking(async move {
+        $crate::executor::blocking(async move {
             $($tokens)*
-        }, lightproc::proc_stack::ProcStack::default())
+        })
     };
 }
 

--- a/src/bastion/src/macros.rs
+++ b/src/bastion/src/macros.rs
@@ -232,11 +232,11 @@ macro_rules! blocking {
 #[macro_export]
 macro_rules! run {
     ($action:expr) => {
-        bastion_executor::run::run($action, lightproc::proc_stack::ProcStack::default())
+        bastion::executor::run($action)
     };
 
     ($($tokens:tt)*) => {
-        bastion_executor::run::run(async move {$($tokens)*}, lightproc::proc_stack::ProcStack::default())
+        bastion::executor::run(async move {$($tokens)*})
     };
 }
 
@@ -255,11 +255,11 @@ macro_rules! run {
 #[macro_export]
 macro_rules! spawn {
     ($action:expr) => {
-        bastion_executor::pool::spawn($action, lightproc::proc_stack::ProcStack::default())
+        bastion::executor::spawn($action)
     };
 
     ($($tokens:tt)*) => {
-        bastion_executor::pool::spawn(async move {$($tokens)*}, lightproc::proc_stack::ProcStack::default())
+        bastion::executor::spawn(async move {$($tokens)*})
     };
 }
 


### PR DESCRIPTION
With these changes we avoid forcing the user to add `bastion_executor` and `lightproc` as direct dependencies if they want to use `blocking!`, `run!` and `spawn!`.
Concern: `RecoverableHandle` is exposed as part of the public API, even though this is just a formalization of what was already happening.

I have matched macro names and function names for simplicity and clarity.