### PR TITLE
Update dependency versions before release (agressive way)

### DIFF
--- a/src/bastion-executor/Cargo.toml
+++ b/src/bastion-executor/Cargo.toml
@@ -31,25 +31,25 @@ unstable = ["numanji", "allocator-suite", "jemallocator"]
 lightproc = { version = "= 0.3.5-alpha.0", path = "../lightproc" }
 bastion-utils = { version = "0.3.2", path = "../bastion-utils" }
 
-crossbeam-utils = "0.7"
-crossbeam-channel = "0.4"
-crossbeam-epoch = "0.8"
-lazy_static = "1.4"
-libc = "0.2"
-num_cpus = "1.10"
-pin-utils = "0.1.0-alpha.4"
+crossbeam-utils = "0.7.2"
+crossbeam-channel = "0.4.2"
+crossbeam-epoch = "0.8.2"
+lazy_static = "1.4.0"
+libc = "0.2.71"
+num_cpus = "1.13.0"
+pin-utils = "0.1.0"
 
 # Allocator
-numanji = { version = "^0.1", optional = true, default-features = false }
-allocator-suite = { version = "^0.1", optional = true, default-features = false }
+numanji = { version = "0.1.2", optional = true, default-features = false }
+allocator-suite = { version = "0.1.4", optional = true, default-features = false }
 
 [target.'cfg(not(any(target_os = "android", target_os = "linux")))'.dependencies]
-jemallocator = { version = "^0.3", optional = true, default-features = false }
+jemallocator = { version = "0.3.2", optional = true, default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "^0.3.8", features = ["basetsd"] }
-kernel32-sys = "^0.2.2"
+winapi = { version = "0.3.9", features = ["basetsd"] }
+kernel32-sys = "0.2.2"
 
 [dev-dependencies]
-proptest = "^0.10"
-futures = "0.3.1"
+proptest = "0.10.0"
+futures = "0.3.5"

--- a/src/bastion/Cargo.toml
+++ b/src/bastion/Cargo.toml
@@ -52,34 +52,34 @@ rustdoc-args = ["--cfg", "feature=\"docs\""]
 bastion-executor = { version = "= 0.3.5-alpha", path = "../bastion-executor" }
 lightproc = { version = "= 0.3.5-alpha.0", path = "../lightproc" }
 
-lever = "0.1.1-alpha.2"
+lever = "0.1.1-alpha.3"
 futures = "0.3.5"
 futures-timer = "3.0.2"
-fxhash = "0.2"
-lazy_static = "1.4"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-pin-utils = "0.1"
+fxhash = "0.2.1"
+lazy_static = "1.4.0"
+serde = { version = "1.0.114", features = ["derive"] }
+serde_json = "1.0.56"
+pin-utils = "0.1.0"
 
 # TODO: https://github.com/cogciprocate/qutex/pull/5
 # TODO: https://github.com/cogciprocate/qutex/pull/6
-bastion-qutex = { version = "0.2", features = ["async_await"] }
-uuid = { version = "0.8", features = ["v4"] }
+bastion-qutex = { version = "0.2.4", features = ["async_await"] }
+uuid = { version = "0.8.1", features = ["v4"] }
 
 # Distributed
 artillery-core = { version = "0.1.0", optional = true }
 
 # Log crates
-tracing-subscriber = "0.2.5"
-tracing = "0.1.13"
+tracing-subscriber = "0.2.6"
+tracing = "0.1.15"
 anyhow = "1.0.31"
 
 [dev-dependencies]
-env_logger = "0.7"
-proptest = "0.10"
-snap = "1.0"
+env_logger = "0.7.1"
+proptest = "0.10.0"
+snap = "1.0.0"
 # prime_numbers example
 bastion-utils = { version = "0.3.2", path = "../bastion-utils" }
 rand = "0.7.3"
-rayon = "1.3.0"
+rayon = "1.3.1"
 num_cpus = "1.13.0"

--- a/src/lightproc/Cargo.toml
+++ b/src/lightproc/Cargo.toml
@@ -17,10 +17,10 @@ travis-ci = { repository = "bastion-rs/bastion", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-crossbeam-utils = "0.7"
-pin-utils = "0.1.0-alpha.4"
+crossbeam-utils = "0.7.2"
+pin-utils = "0.1.0"
 
 [dev-dependencies]
-crossbeam = "0.7"
-futures-preview = "=0.3.0-alpha.19"
-lazy_static = "1.3.0"
+crossbeam = "0.7.3"
+futures-preview = "0.3.0-alpha.19"
+lazy_static = "1.4.0"


### PR DESCRIPTION
Issue #226 

I did it with [cargo upgrade](https://crates.io/crates/cargo-edit).

We have to choose between #229 and it.
