### PR TITLE
(docs) use run! instead of await in Bastion docs

### DIFF
--- a/src/bastion/src/bastion.rs
+++ b/src/bastion/src/bastion.rs
@@ -139,7 +139,7 @@ distributed_api! {
 ///     let answer: Answer = child.ask_anonymously("A message containing data.").expect("Couldn't send the message.");
 ///     # async {
 ///     // ...until the child eventually answers back...
-///     let answer: Result<SignedMessage, ()> = answer.await;
+///     let answer: Result<SignedMessage, ()> = run!(answer);
 ///     # };
 ///
 ///     // ...and then even stop or kill it...


### PR DESCRIPTION
Hey, @o0Ignition0o So to get started, I ran the tests only in `Bastion` with:
`cargo test --doc --package bastion -- bastion::Bastion --nocapture`
I was expecting the code blocks in Bastion struct's doc tests to fail as we have an `await!` there.
I am wondering why the tests are passing in `Bastion::*` without this fix? 
Doc tests are run similar to code in a `main` function; right (which doesn't allow `await!`)?

For the fix, I have added the `run!` macro.
Let me know if I missed anything.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bastion-rs/.github/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] tests are passing with `cargo test`. 
- [X] documentation is changed or added
- [X] commit message is clear

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
