### PR TITLE
Fix RestartStrategy::timeout < 1s

### DIFF
--- a/src/bastion/src/supervisor.rs
+++ b/src/bastion/src/supervisor.rs
@@ -239,7 +239,7 @@ impl ActorRestartStrategy {
                 let delay = timeout.mul_f64(factor);
                 Some(timeout + delay)
             }
-            _ => None 
+            _ => None,
         }
     }
 
@@ -1912,7 +1912,6 @@ impl RestartStrategy {
         self.strategy = strategy;
         self
     }
-
 
     pub(crate) async fn apply_strategy(&self, restarts_count: usize) {
         if let Some(dur) = self.strategy.calculate(restarts_count) {

--- a/src/bastion/src/supervisor.rs
+++ b/src/bastion/src/supervisor.rs
@@ -242,7 +242,6 @@ impl ActorRestartStrategy {
             _ => None,
         }
     }
-
 }
 
 impl Supervisor {

--- a/src/bastion/src/supervisor.rs
+++ b/src/bastion/src/supervisor.rs
@@ -189,13 +189,13 @@ pub enum RestartPolicy {
 ///
 /// The default strategy used is `ActorRestartStrategy::Immediate`
 /// with the `RestartPolicy::Always` restart policy.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RestartStrategy {
     restart_policy: RestartPolicy,
     strategy: ActorRestartStrategy,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 /// The strategy for restating an actor as far as it
 /// returned an failure.
 ///
@@ -219,7 +219,7 @@ pub enum ActorRestartStrategy {
         /// An initial delay before the restarting an actor.
         timeout: Duration,
         /// Defines a multiplier how fast the timeout will be increasing.
-        multiplier: u32,
+        multiplier: f64,
     },
 }
 
@@ -228,15 +228,15 @@ impl ActorRestartStrategy {
     pub fn calculate(&self, restarts_count: usize) -> Option<Duration> {
         match *self {
             ActorRestartStrategy::LinearBackOff { timeout } => {
-                let delay = timeout * restarts_count as u32;
+                let delay = timeout.mul_f64(restarts_count as f64);
                 Some(timeout + delay)
             }
             ActorRestartStrategy::ExponentialBackOff {
                 timeout,
                 multiplier,
             } => {
-                let factor = multiplier * restarts_count as u32;
-                let delay = timeout * factor;
+                let factor = multiplier * restarts_count as f64;
+                let delay = timeout.mul_f64(factor);
                 Some(timeout + delay)
             }
             _ => None 
@@ -755,7 +755,7 @@ impl Supervisor {
     ///         .with_actor_restart_strategy(           
     ///             ActorRestartStrategy::ExponentialBackOff {
     ///                 timeout: Duration::from_millis(5000),
-    ///                 multiplier: 3,
+    ///                 multiplier: 3.0,
     ///             }
     ///         )
     /// )

--- a/src/bastion/src/supervisor.rs
+++ b/src/bastion/src/supervisor.rs
@@ -1901,9 +1901,9 @@ impl RestartStrategy {
                 timeout,
                 multiplier,
             } => {
-                let start_in =
-                    timeout.as_secs() + (timeout.as_secs() * multiplier * restarts_count as u64);
-                Delay::new(Duration::from_secs(start_in)).await;
+                let factor = multiplier as u32 * restarts_count as u32;
+                let delay = timeout * factor;
+                Delay::new(timeout + delay).await;
             }
             _ => {}
         };

--- a/src/bastion/tests/restart_strategy.rs
+++ b/src/bastion/tests/restart_strategy.rs
@@ -1,5 +1,5 @@
 use bastion::supervisor::{ActorRestartStrategy, RestartPolicy, RestartStrategy};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[test]
 fn check_default_values() {
@@ -42,4 +42,62 @@ fn override_restart_strategy_and_policy() {
 
     assert_eq!(restart_strategy.restart_policy(), policy);
     assert_eq!(restart_strategy.strategy(), strategy);
+}
+
+#[test]
+fn calculate_immediate_strategy() {
+    let strategy = ActorRestartStrategy::Immediate;
+
+    assert_eq!(strategy.calculate(0), None);
+    assert_eq!(strategy.calculate(1), None);
+    assert_eq!(strategy.calculate(100), None);
+}
+
+#[test]
+fn calculate_linear_strategy() {
+    let strategy = ActorRestartStrategy::LinearBackOff {
+        timeout: Duration::from_millis(100),
+    };
+
+    assert_eq!(strategy.calculate(0), Some(Duration::from_millis(100)));
+
+    assert_eq!(
+        strategy.calculate(1),
+        Some(Duration::from_millis(100 + 1 * 100))
+    );
+    assert_eq!(
+        strategy.calculate(99),
+        Some(Duration::from_millis(100 + 99 * 100))
+    );
+}
+
+#[test]
+fn calculate_exp_strategy_with_multiplier_zero() {
+    let strategy = ActorRestartStrategy::ExponentialBackOff {
+        timeout: Duration::from_millis(100),
+        multiplier: 0,
+    };
+
+    assert_eq!(strategy.calculate(0), Some(Duration::from_millis(100)));
+    assert_eq!(strategy.calculate(1), Some(Duration::from_millis(100)));
+    assert_eq!(strategy.calculate(100), Some(Duration::from_millis(100)));
+}
+
+#[test]
+fn calculate_exp_strategy_with_multiplier_non_zero() {
+    let strategy = ActorRestartStrategy::ExponentialBackOff {
+        timeout: Duration::from_millis(100),
+        multiplier: 5,
+    };
+
+    assert_eq!(strategy.calculate(0), Some(Duration::from_millis(100)));
+
+    assert_eq!(
+        strategy.calculate(1),
+        Some(Duration::from_millis(100 + 1 * 5 * 100))
+    );
+    assert_eq!(
+        strategy.calculate(99),
+        Some(Duration::from_millis(100 + 99 * 5 * 100))
+    );
 }

--- a/src/bastion/tests/restart_strategy.rs
+++ b/src/bastion/tests/restart_strategy.rs
@@ -75,7 +75,7 @@ fn calculate_linear_strategy() {
 fn calculate_exp_strategy_with_multiplier_zero() {
     let strategy = ActorRestartStrategy::ExponentialBackOff {
         timeout: Duration::from_millis(100),
-        multiplier: 0,
+        multiplier: 0.0,
     };
 
     assert_eq!(strategy.calculate(0), Some(Duration::from_millis(100)));
@@ -87,7 +87,7 @@ fn calculate_exp_strategy_with_multiplier_zero() {
 fn calculate_exp_strategy_with_multiplier_non_zero() {
     let strategy = ActorRestartStrategy::ExponentialBackOff {
         timeout: Duration::from_millis(100),
-        multiplier: 5,
+        multiplier: 5.0,
     };
 
     assert_eq!(strategy.calculate(0), Some(Duration::from_millis(100)));

--- a/src/bastion/tests/restart_strategy.rs
+++ b/src/bastion/tests/restart_strategy.rs
@@ -1,5 +1,5 @@
 use bastion::supervisor::{ActorRestartStrategy, RestartPolicy, RestartStrategy};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 #[test]
 fn check_default_values() {

--- a/src/bastion/tests/restart_strategy.rs
+++ b/src/bastion/tests/restart_strategy.rs
@@ -1,5 +1,5 @@
 use bastion::supervisor::{ActorRestartStrategy, RestartPolicy, RestartStrategy};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[test]
 fn check_default_values() {


### PR DESCRIPTION
Fix issue where fractions of a second are ignored internally. This leads to a broken `RestartStrategy` when given a timeout of eg. `Duration::from_millis(999)`. NOTE: The type casting of `multiplier` can get removed but that would be a breaking change. I leave this for the reviewer to decide.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bastion-rs/.github/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are passing with `cargo test`. 
- [ ] tests and/or benchmarks are included
- [x] commit message is clear

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
