### PR TITLE
override the redundancy based on the resizer

### DIFF
--- a/src/bastion/src/children.rs
+++ b/src/bastion/src/children.rs
@@ -314,6 +314,10 @@ impl Children {
         } else {
             self.redundancy = redundancy;
         }
+        #[cfg(feature = "scaling")]
+        {
+            self.resizer.set_lower_bound(self.redundancy as u64);
+        }
 
         self
     }
@@ -383,7 +387,8 @@ impl Children {
     /// # }
     /// ```
     /// [`Resizer`]: ../resizer/struct.Resizer.html
-    pub fn with_resizer(mut self, resizer: OptimalSizeExploringResizer) -> Self {
+    pub fn with_resizer(mut self, mut resizer: OptimalSizeExploringResizer) -> Self {
+        self.redundancy = resizer.lower_bound() as usize;
         self.resizer = Box::new(resizer);
         self
     }

--- a/src/bastion/src/resizer.rs
+++ b/src/bastion/src/resizer.rs
@@ -112,9 +112,23 @@ impl OptimalSizeExploringResizer {
         self.actor_stats.clone()
     }
 
+    /// Returns lower bound of the number of actors in the scaling group.
+    pub(crate) fn lower_bound(&self) -> u64 {
+        self.lower_bound
+    }
+
+    /// Set lower bound of the autoscaling group.
+    pub(crate) fn set_lower_bound(&mut self, lower_bound: u64) {
+        self.lower_bound = lower_bound;
+    }
+
     /// Overrides the minimal amount of actors available to use.
     pub fn with_lower_bound(mut self, lower_bound: u64) -> Self {
-        self.lower_bound = lower_bound;
+        if lower_bound == u64::MIN {
+            self.lower_bound = lower_bound.saturating_add(1);
+        } else {
+            self.lower_bound = lower_bound;
+        }
         self
     }
 


### PR DESCRIPTION
```
  let mut children = children
        .with_redundancy(3) // Start with 3 actors
        .with_heartbeat_tick(Duration::from_secs(5)); // Do heartbeat each 5 seconds

    #[cfg(feature = "scaling")]
    {
        children = children.with_resizer(
            OptimalSizeExploringResizer::default()
                .with_lower_bound(1) // A minimal acceptable size of group
                .with_upper_bound(UpperBound::Limit(2)) 
                .with_upscale_strategy(UpscaleStrategy::MailboxSizeThreshold(3)) // Scale up when a half of actors have more than 3 messages
                .with_upscale_rate(0.1) // Increase the size of group on 10%, if necessary to scale up
                .with_downscale_rate(0.2), // Decrease the size of group on 20%, if too many free actors
        );
    }
```
The above code will panic at https://github.com/bastion-rs/bastion/blob/master/src/bastion/src/resizer.rs#L254 because redundancy is 3 is higher than the upper bound.

This PR overwrites the minimum number actor will be spawned based on the recent argument pass. It can be via a `resizer` or `redundancy`. 


Still, we need to catch the places like lower bound can't be higher than the upper bound. Wondering how we can put such sanity checks ergonomically. 
