### PR TITLE
Translate doc link to intra-doc-link, fix broken links

### DIFF
--- a/src/bastion-executor/src/blocking.rs
+++ b/src/bastion-executor/src/blocking.rs
@@ -1,8 +1,10 @@
 //!
 //! Pool of threads to run heavy processes
 //!
-//! We spawn futures onto the pool with [spawn_blocking] method of global run queue or
-//! with corresponding [Worker]'s spawn method.
+//! We spawn futures onto the pool with [`spawn_blocking`] method of global run queue or
+//! with corresponding [`Worker`]'s spawn method.
+//!
+//! [`Worker`]: crate::run_queue::Worker
 
 use crate::thread_manager::{DynamicPoolManager, DynamicRunner};
 use crossbeam_channel::{unbounded, Receiver, Sender};

--- a/src/bastion-executor/src/pool.rs
+++ b/src/bastion-executor/src/pool.rs
@@ -1,8 +1,11 @@
 //!
 //! Pool of threads to run lightweight processes
 //!
-//! We spawn futures onto the pool with [spawn] method of global run queue or
-//! with corresponding [Worker]'s spawn method.
+//! We spawn futures onto the pool with [`spawn`] method of global run queue or
+//! with corresponding [`Worker`]'s spawn method.
+//!
+//! [`spawn`]: crate::pool::spawn
+//! [`Worker`]: crate::run_queue::Worker
 
 use crate::thread_manager::{DynamicPoolManager, DynamicRunner};
 use crate::worker;

--- a/src/bastion-executor/src/run_queue.rs
+++ b/src/bastion-executor/src/run_queue.rs
@@ -18,39 +18,34 @@
 //!
 //! [`Worker`] has two constructors:
 //!
-//! * [`new_fifo()`] - Creates a FIFO queue, in which tasks are pushed and popped from opposite
+//! * [`new_fifo`] - Creates a FIFO queue, in which tasks are pushed and popped from opposite
 //!   ends.
-//! * [`new_lifo()`] - Creates a LIFO queue, in which tasks are pushed and popped from the same
+//! * [`new_lifo`] - Creates a LIFO queue, in which tasks are pushed and popped from the same
 //!   end.
 //!
 //! Each [`Worker`] is owned by a single thread and supports only push and pop operations.
 //!
-//! Method [`stealer()`] creates a [`Stealer`] that may be shared among threads and can only steal
+//! Method [`stealer`] creates a [`Stealer`] that may be shared among threads and can only steal
 //! tasks from its [`Worker`]. Tasks are stolen from the end opposite to where they get pushed.
 //!
 //! # Stealing
 //!
 //! Steal operations come in three flavors:
 //!
-//! 1. [`steal()`] - Steals one task.
-//! 2. [`steal_batch()`] - Steals a batch of tasks and moves them into another worker.
-//! 3. [`steal_batch_and_pop()`] - Steals a batch of tasks, moves them into another queue, and pops
+//! 1. [`steal`] - Steals one task.
+//! 2. [`steal_batch`] - Steals a batch of tasks and moves them into another worker.
+//! 3. [`steal_batch_and_pop`] - Steals a batch of tasks, moves them into another queue, and pops
 //!    one task from that worker.
 //!
 //! In contrast to push and pop operations, stealing can spuriously fail with [`Steal::Retry`], in
 //! which case the steal operation needs to be retried.
 //!
-//!
-//! [`Worker`]: struct.Worker.html
-//! [`Stealer`]: struct.Stealer.html
-//! [`Injector`]: struct.Injector.html
-//! [`Steal::Retry`]: enum.Steal.html#variant.Retry
-//! [`new_fifo()`]: struct.Worker.html#method.new_fifo
-//! [`new_lifo()`]: struct.Worker.html#method.new_lifo
-//! [`stealer()`]: struct.Worker.html#method.stealer
-//! [`steal()`]: struct.Stealer.html#method.steal
-//! [`steal_batch()`]: struct.Stealer.html#method.steal_batch
-//! [`steal_batch_and_pop()`]: struct.Stealer.html#method.steal_batch_and_pop
+//! [`new_fifo`]: Worker::new_fifo
+//! [`new_lifo`]: Worker::new_lifo
+//! [`stealer`]: Worker::stealer
+//! [`steal`]: Stealer::steal
+//! [`steal_batch`]: Stealer::steal_batch
+//! [`steal_batch_and_pop`]: Stealer::steal_batch_and_pop
 use crossbeam_epoch::{self as epoch, Atomic, Owned};
 use crossbeam_utils::{Backoff, CachePadded};
 use std::cell::{Cell, UnsafeCell};
@@ -1784,10 +1779,14 @@ impl<T> fmt::Debug for Steal<T> {
 }
 
 impl<T> FromIterator<Steal<T>> for Steal<T> {
-    /// Consumes items until a `Success` is found and returns it.
+    /// Consumes items until a [`Success`] is found and returns it.
     ///
-    /// If no `Success` was found, but there was at least one `Retry`, then returns `Retry`.
-    /// Otherwise, `Empty` is returned.
+    /// If no [`Success`] was found, but there was at least one [`Retry`], then returns [`Retry`].
+    /// Otherwise, [`Empty`] is returned.
+    ///
+    /// [`Success`]: Steal::Success
+    /// [`Retry`]: Steal::Retry
+    /// [`Empty`]: Steal::Empty
     fn from_iter<I>(iter: I) -> Steal<T>
     where
         I: IntoIterator<Item = Steal<T>>,

--- a/src/bastion/src/bastion.rs
+++ b/src/bastion/src/bastion.rs
@@ -206,9 +206,6 @@ impl Bastion {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`Config`]: struct.Config.html
-    /// [`Bastion::init_with`]: #method.init_with
     pub fn init() {
         let config = Config::default();
         Bastion::init_with(config)
@@ -254,9 +251,6 @@ impl Bastion {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`Config`]: struct.Config.html
-    /// [`Bastion::init`]: #method.init
     pub fn init_with(config: Config) {
         debug!("Bastion: Initializing with config: {:?}", config);
         if config.backtraces().is_hide() {
@@ -310,9 +304,6 @@ impl Bastion {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`Supervisor`]: supervisor/struct.Supervisor.html
-    /// [`SupervisorRef`]: supervisor/struct.SupervisorRef.html
     pub fn supervisor<S>(init: S) -> Result<SupervisorRef, ()>
     where
         S: FnOnce(Supervisor) -> Supervisor,
@@ -392,9 +383,6 @@ impl Bastion {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`Children`]: children/struct.Children.html
-    /// [`ChildrenRef`]: children/struct.ChildrenRef.html
     pub fn children<C>(init: C) -> Result<ChildrenRef, ()>
     where
         C: FnOnce(Children) -> Children,
@@ -446,11 +434,6 @@ impl Bastion {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`Children::with_exec`]: children/struct.Children.html#method.with_exec
-    /// [`Bastion::children`]: #method.children
-    /// [`Children`]: children/struct.Children.html
-    /// [`ChildrenRef`]: children/struct.ChildrenRef.html
     pub fn spawn<I, F>(action: I) -> Result<ChildrenRef, ()>
     where
         I: Fn(BastionContext) -> F + Send + 'static,
@@ -674,7 +657,7 @@ impl Bastion {
     }
 
     /// Blocks the current thread until the system is stopped
-    /// (either by calling [`Bastion::stop()`] or
+    /// (either by calling [`Bastion::stop`] or
     /// [`Bastion::kill`]).
     ///
     /// # Example
@@ -708,9 +691,6 @@ impl Bastion {
     /// // stopped or killed it...
     /// # }
     /// ```
-    ///
-    /// [`Bastion::stop()`]: #method.stop
-    /// [`Bastion::kill()`]: #method.kill
     pub fn block_until_stopped() {
         debug!("Bastion: Blocking until system is stopped.");
         SYSTEM.wait_until_stopped();

--- a/src/bastion/src/callbacks.rs
+++ b/src/bastion/src/callbacks.rs
@@ -56,8 +56,8 @@ pub(crate) enum CallbackType {
 /// # }
 /// ```
 ///
-/// [`Supervisor`]: supervisor/struct.Supervisor.html
-/// [`Children`]: children/struct.Children.html
+/// [`Supervisor`]: crate::supervisor::Supervisor
+/// [`Children`]: crate::children::Children
 pub struct Callbacks {
     before_start: Option<Arc<dyn Fn() + Send + Sync>>,
     before_restart: Option<Arc<dyn Fn() + Send + Sync>>,
@@ -111,8 +111,8 @@ impl Callbacks {
     /// # }
     /// ```
     ///
-    /// [`Supervisor::with_callbacks`]: supervisor/struct.Supervisor.html#method.with_callbacks
-    /// [`Children::with_callbacks`]: children/struct.Children.html#method.with_callbacks
+    /// [`Supervisor::with_callbacks`]: crate::supervisor::Supervisor::with_callbacks
+    /// [`Children::with_callbacks`]: crate::children::Children::with_callbacks
     pub fn new() -> Self {
         Callbacks::default()
     }
@@ -179,9 +179,9 @@ impl Callbacks {
     /// # }
     /// ```
     ///
-    /// [`Supervisor`]: supervisor/struct.Supervisor.html
-    /// [`Children`]: children/struct.Children.html
-    /// [`with_after_restart`]: #method.with_after_start
+    /// [`Supervisor`]: crate::supervisor::Supervisor
+    /// [`Children`]: crate::children::Children
+    /// [`with_after_restart`]: Self::with_after_restart
     pub fn with_before_start<C>(mut self, before_start: C) -> Self
     where
         C: Fn() + Send + Sync + 'static,
@@ -253,9 +253,9 @@ impl Callbacks {
     /// # }
     /// ```
     ///
-    /// [`Supervisor`]: supervisor/struct.Supervisor.html
-    /// [`Children`]: children/struct.Children.html
-    /// [`with_after_stop`]: #method.with_after_stop
+    /// [`Supervisor`]: crate::supervisor::Supervisor
+    /// [`Children`]: crate::children::Children
+    /// [`with_after_stop`]: Self::with_after_stop
     pub fn with_before_restart<C>(mut self, before_restart: C) -> Self
     where
         C: Fn() + Send + Sync + 'static,
@@ -327,9 +327,9 @@ impl Callbacks {
     /// # }
     /// ```
     ///
-    /// [`Supervisor`]: supervisor/struct.Supervisor.html
-    /// [`Children`]: children/struct.Children.html
-    /// [`with_before_start`]: #method.with_before_start
+    /// [`Supervisor`]: crate::supervisor::Supervisor
+    /// [`Children`]: crate::children::Children
+    /// [`with_before_start`]: Self::method.with_before_start
     pub fn with_after_restart<C>(mut self, after_restart: C) -> Self
     where
         C: Fn() + Send + Sync + 'static,
@@ -403,9 +403,9 @@ impl Callbacks {
     /// # }
     /// ```
     ///
-    /// [`Supervisor`]: supervisor/struct.Supervisor.html
-    /// [`Children`]: children/struct.Children.html
-    /// [`with_before_restart`]: #method.with_before_restart
+    /// [`Supervisor`]: crate::supervisor::Supervisor
+    /// [`Children`]: crate::children::Children
+    /// [`with_before_restart`]: Self::with_before_restart
     pub fn with_after_stop<C>(mut self, after_stop: C) -> Self
     where
         C: Fn() + Send + Sync + 'static,
@@ -428,7 +428,7 @@ impl Callbacks {
     /// assert!(callbacks.has_before_start());
     /// ```
     ///
-    /// [`with_before_start`]: #method.with_before_start
+    /// [`with_before_start`]: Self::with_before_start
     pub fn has_before_start(&self) -> bool {
         self.before_start.is_some()
     }
@@ -446,7 +446,7 @@ impl Callbacks {
     /// assert!(callbacks.has_before_restart());
     /// ```
     ///
-    /// [`with_before_restart`]: #method.with_before_restart
+    /// [`with_before_restart`]: Self::with_before_restart
     pub fn has_before_restart(&self) -> bool {
         self.before_restart.is_some()
     }
@@ -464,7 +464,7 @@ impl Callbacks {
     /// assert!(callbacks.has_after_restart());
     /// ```
     ///
-    /// [`with_after_restart`]: #method.with_after_restart
+    /// [`with_after_restart`]: Self::with_after_restart
     pub fn has_after_restart(&self) -> bool {
         self.after_restart.is_some()
     }
@@ -482,7 +482,7 @@ impl Callbacks {
     /// assert!(callbacks.has_after_stop());
     /// ```
     ///
-    /// [`with_after_stop`]: #method.with_after_stop
+    /// [`with_after_stop`]: Self::with_after_stop
     pub fn has_after_stop(&self) -> bool {
         self.after_stop.is_some()
     }

--- a/src/bastion/src/child_ref.rs
+++ b/src/bastion/src/child_ref.rs
@@ -303,7 +303,6 @@ impl ChildRef {
     /// # }
     /// ```
     ///
-    /// [`Answer`]: message/struct.Answer.html
     pub fn ask_anonymously<M: Message>(&self, msg: M) -> Result<Answer, M> {
         debug!("ChildRef({}): Asking message: {:?}", self.id(), msg);
         let (msg, answer) = BastionMessage::ask(msg);
@@ -435,7 +434,7 @@ impl ChildRef {
         &self.path
     }
 
-    /// Return the [`name`] of the child
+    /// Return the `name` of the child
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/src/bastion/src/children.rs
+++ b/src/bastion/src/children.rs
@@ -85,9 +85,9 @@ use tracing::{debug, trace, warn};
 /// # }
 /// ```
 ///
-/// [`with_redundancy`]: #method.with_redundancy
-/// [`with_exec`]: #method.with_exec
-/// [`SupervisionStrategy`]: supervisor/enum.SupervisionStrategy.html
+/// [`with_redundancy`]: Self::with_redundancy
+/// [`with_exec`]: Self::with_exec
+/// [`SupervisionStrategy`]: crate::supervisor::SupervisionStrategy
 pub struct Children {
     bcast: Broadcast,
     // The currently launched elements of the group.
@@ -354,7 +354,7 @@ impl Children {
     /// # }
     /// ```
     ///
-    /// [`with_exec`]: #method.with_exec
+    /// [`with_exec`]: Self::with_exec
     pub fn with_redundancy(mut self, redundancy: usize) -> Self {
         trace!(
             "Children({}): Setting redundancy: {}",
@@ -414,7 +414,7 @@ impl Children {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    /// [`DispatcherHandler`]: ../dispatcher/trait.DispatcherHandler.html
+    /// [`DispatcherHandler`]: crate::dispatcher::DispatcherHandler
     pub fn with_dispatcher(mut self, dispatcher: Dispatcher) -> Self {
         self.dispatchers.push(Arc::new(Box::new(dispatcher)));
         self
@@ -462,7 +462,6 @@ impl Children {
     ///     # Bastion::block_until_stopped();
     /// # }
     /// ```
-    /// [`Resizer`]: ../resizer/struct.Resizer.html
     pub fn with_resizer(mut self, mut resizer: OptimalSizeExploringResizer) -> Self {
         self.redundancy = resizer.lower_bound() as usize;
         self.resizer = Box::new(resizer);
@@ -521,8 +520,6 @@ impl Children {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`Callbacks`]: struct.Callbacks.html
     pub fn with_callbacks(mut self, callbacks: Callbacks) -> Self {
         trace!(
             "Children({}): Setting callbacks: {:?}",
@@ -579,7 +576,6 @@ impl Children {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    /// [`std::time::Duration`]: https://doc.rust-lang.org/nightly/core/time/struct.Duration.html
     pub fn with_heartbeat_tick(mut self, interval: Duration) -> Self {
         trace!(
             "Children({}): Set heartbeat tick to {:?}",

--- a/src/bastion/src/children_ref.rs
+++ b/src/bastion/src/children_ref.rs
@@ -112,8 +112,6 @@ impl ChildrenRef {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`ChildRef`]: children/struct.ChildRef.html
     pub fn dispatchers(&self) -> &Vec<DispatcherType> {
         &self.dispatchers
     }
@@ -148,8 +146,6 @@ impl ChildrenRef {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`ChildRef`]: children/struct.ChildRef.html
     pub fn elems(&self) -> &[ChildRef] {
         &self.children
     }
@@ -216,7 +212,7 @@ impl ChildrenRef {
     /// # }
     /// ```
     ///
-    /// [`elems`]: #method.elems
+    /// [`elems`]: Self::elems
     pub fn broadcast<M: Message>(&self, msg: M) -> Result<(), M> {
         debug!(
             "ChildrenRef({}): Broadcasting message: {:?}",

--- a/src/bastion/src/config.rs
+++ b/src/bastion/src/config.rs
@@ -34,7 +34,7 @@
 /// # }
 /// ```
 ///
-/// [`Bastion::init_with`]: struct.Bastion.html#method.init_with
+/// [`Bastion::init_with`]: crate::Bastion::init_with
 pub struct Config {
     backtraces: Backtraces,
 }
@@ -53,8 +53,6 @@ impl Config {
     /// Creates a new configuration with the following default
     /// behaviors:
     /// - All backtraces are shown (see [`Config::show_backtraces`]).
-    ///
-    /// [`Config::show_backtraces`]: #method.show_backtraces
     pub fn new() -> Self {
         Config::default()
     }
@@ -133,8 +131,6 @@ impl Config {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`Config::show_backtraces`]: #method.show_backtraces
     pub fn hide_backtraces(mut self) -> Self {
         self.backtraces = Backtraces::hide();
         self

--- a/src/bastion/src/context.rs
+++ b/src/bastion/src/context.rs
@@ -74,7 +74,7 @@ pub const NIL_ID: BastionId = BastionId(Uuid::nil());
 pub struct BastionId(pub(crate) Uuid);
 
 #[derive(Debug)]
-/// A child's execution context, allowing its [`exec`] future
+/// A child's execution context, allowing its [`with_exec`] future
 /// to receive messages and access a [`ChildRef`] referencing
 /// it, a [`ChildrenRef`] referencing its children group and
 /// a [`SupervisorRef`] referencing its supervisor.
@@ -130,6 +130,8 @@ pub struct BastionId(pub(crate) Uuid);
 /// # Bastion::block_until_stopped();
 /// # }
 /// ```
+///
+/// [`with_exec`]: crate::children::Children::with_exec
 pub struct BastionContext {
     id: BastionId,
     child: ChildRef,
@@ -212,8 +214,6 @@ impl BastionContext {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`ChildRef`]: children/struct.ChildRef.html
     pub fn current(&self) -> &ChildRef {
         &self.child
     }
@@ -257,8 +257,6 @@ impl BastionContext {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`ChildrenRef`]: children/struct.ChildrenRef.html
     pub fn parent(&self) -> &ChildrenRef {
         &self.children
     }
@@ -325,7 +323,6 @@ impl BastionContext {
     /// # }
     /// ```
     ///
-    /// [`SupervisorRef`]: supervisor/struct.SupervisorRef.html
     /// [`Bastion::children`]: struct.Bastion.html#method.children
     pub fn supervisor(&self) -> Option<&SupervisorRef> {
         self.supervisor.as_ref()
@@ -380,9 +377,8 @@ impl BastionContext {
     /// # }
     /// ```
     ///
-    /// [`recv`]: #method.recv
-    /// [`try_recv_timeout`]: #method.try_recv_timeout
-    /// [`SignedMessage`]: ../prelude/struct.SignedMessage.html
+    /// [`recv`]: Self::method.recv
+    /// [`try_recv_timeout`]: Self::method.try_recv_timeout
     pub async fn try_recv(&self) -> Option<SignedMessage> {
         // We want to let a tick pass
         // otherwise guard will never contain anything.
@@ -448,9 +444,8 @@ impl BastionContext {
     /// # }
     /// ```
     ///
-    /// [`try_recv`]: #method.try_recv
-    /// [`try_recv_timeout`]: #method.try_recv_timeout
-    /// [`SignedMessage`]: ../prelude/struct.SignedMessage.html
+    /// [`try_recv`]: Self::try_recv
+    /// [`try_recv_timeout`]: Self::try_recv_timeout
     pub async fn recv(&self) -> Result<SignedMessage, ()> {
         debug!("BastionContext({}): Waiting to receive message.", self.id);
         loop {
@@ -517,9 +512,9 @@ impl BastionContext {
     /// # }
     /// ```
     ///
-    /// [`recv`]: #method.recv
-    /// [`try_recv`]: #method.try_recv
-    /// [`SignedMessage`]: ../prelude/struct.SignedMessage.html
+    /// [`recv`]: Self::recv
+    /// [`try_recv`]: Self::try_recv
+    /// [`SignedMessage`]: .crate::enveloppe::SignedMessage
     pub async fn try_recv_timeout(&self, timeout: Duration) -> Result<SignedMessage, ReceiveError> {
         debug!(
             "BastionContext({}): Waiting to receive message within {} milliseconds.",
@@ -574,7 +569,8 @@ impl BastionContext {
     /// # }
     /// ```
     ///
-    /// [`RefAddr`]: /prelude/struct.Answer.html
+    // TODO(scrabsha): should we link to Answer or to RefAddr?
+    // [`RefAddr`]: /prelude/struct.Answer.html
     pub fn signature(&self) -> RefAddr {
         RefAddr::new(
             self.current().path().clone(),
@@ -627,8 +623,6 @@ impl BastionContext {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`RefAddr`]: ../prelude/struct.RefAddr.html
     pub fn tell<M: Message>(&self, to: &RefAddr, msg: M) -> Result<(), M> {
         debug!(
             "{:?}: Telling message: {:?} to: {:?}",
@@ -729,8 +723,6 @@ impl BastionContext {
     ///     # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`Answer`]: /message/struct.Answer.html
     pub fn ask<M: Message>(&self, to: &RefAddr, msg: M) -> Result<Answer, M> {
         debug!(
             "{:?}: Asking message: {:?} to: {:?}",
@@ -770,7 +762,6 @@ impl BastionContext {
     /// the [`BroadcastTarget`] value.
     /// * `message` - The broadcasted message.
     ///
-    /// [`BroadcastTarget`]: ../dispatcher/enum.DispatcherType.html
     pub fn broadcast_message<M: Message>(&self, target: BroadcastTarget, message: M) {
         let msg = Arc::new(SignedMessage {
             msg: Msg::broadcast(message),

--- a/src/bastion/src/errors.rs
+++ b/src/bastion/src/errors.rs
@@ -8,7 +8,10 @@ use std::time::Duration;
 
 #[derive(Debug)]
 /// These errors happen
-/// when try_recv() or try_recv_timeout() are invoked
+/// when [`try_recv`] or [`try_recv_timeout`] are invoked
+///
+/// [`try_recv`]: crate::context::BastionContext::try_recv
+/// [`try_recv_timeout`]: crate::context::BastionContext::try_recv_timeout
 pub enum ReceiveError {
     /// We didn't receive a message on time
     Timeout(Duration),

--- a/src/bastion/src/message.rs
+++ b/src/bastion/src/message.rs
@@ -26,10 +26,10 @@ use tracing::{debug, trace};
 /// implement the following traits: [`Any`], [`Send`],
 /// [`Sync`] and [`Debug`]).
 ///
-/// [`Any`]: https://doc.rust-lang.org/std/any/trait.Any.html
-/// [`Send`]: https://doc.rust-lang.org/std/marker/trait.Send.html
-/// [`Sync`]: https://doc.rust-lang.org/std/marker/trait.Sync.html
-/// [`Debug`]: https://doc.rust-lang.org/std/fmt/trait.Debug.html
+/// [`Any`]: std::any::Any
+/// [`Send`]: std::marker::Send
+/// [`Sync`]: std::marker::Sync
+/// [`Debug`]: std::fmt::Debug
 pub trait Message: Any + Send + Sync + Debug {}
 impl<T> Message for T where T: Any + Send + Sync + Debug {}
 
@@ -39,7 +39,7 @@ pub struct AnswerSender(oneshot::Sender<SignedMessage>);
 
 #[derive(Debug)]
 /// A [`Future`] returned when successfully "asking" a
-/// message using [`ChildRef::ask`] and which resolves to
+/// message using [`ChildRef::ask_anonymously`] and which resolves to
 /// a `Result<Msg, ()>` where the [`Msg`] is the message
 /// answered by the child (see the [`msg!`] macro for more
 /// information).
@@ -120,10 +120,8 @@ pub struct AnswerSender(oneshot::Sender<SignedMessage>);
 /// # }
 /// ```
 ///
-/// [`Future`]: https://doc.rust-lang.org/std/future/trait.Future.html
-/// [`ChildRef::ask`]: ../children/struct.ChildRef.html#method.ask
-/// [`Msg`]: message/struct.Msg.html
-/// [`msg!`]: macro.msg.html
+/// [`Future`]: std::future::Future
+/// [`ChildRef::ask_anonymously`]: crate::child_ref::ChildRef::ask_anonymously
 pub struct Answer(Receiver<SignedMessage>);
 
 #[derive(Debug)]
@@ -193,9 +191,8 @@ pub struct Answer(Receiver<SignedMessage>);
 /// # }
 /// ```
 ///
-/// [`BastionContext::recv`]: context/struct.BastionContext.html#method.recv
-/// [`BastionContext::try_recv`]: context/struct.BastionContext.html#method.try_recv
-/// [`msg!`]: macro.msg.html
+/// [`BastionContext::recv`]: crate::context::BastionContext::recv
+/// [`BastionContext::try_recv`]: crate::context::BastionContext::try_recv
 pub struct Msg(MsgInner);
 
 #[derive(Debug)]
@@ -658,9 +655,8 @@ impl Future for Answer {
 /// # }
 /// ```
 ///
-/// [`Msg`]: children/struct.Msg.html
-/// [`BastionContext::recv`]: context/struct.BastionContext.html#method.recv
-/// [`BastionContext::try_recv`]: context/struct.BastionContext.html#method.try_recv
+/// [`BastionContext::recv`]: crate::context::BastionContext::recv
+/// [`BastionContext::try_recv`]: crate::context::BastionContext::try_recv
 macro_rules! msg {
     ($msg:expr, $($tokens:tt)+) => {
         msg!(@internal $msg, (), (), (), $($tokens)+)

--- a/src/bastion/src/supervisor.rs
+++ b/src/bastion/src/supervisor.rs
@@ -70,10 +70,8 @@ use tracing::{debug, trace, warn};
 /// # }
 /// ```
 ///
-/// [`Children`]: children/struct.Children.html
-/// [`SupervisionStrategy`]: supervisor/enum.SupervisionStrategy.html
-/// [`with_strategy`]: #method.with_strategy
-/// [`Bastion::children`]: struct.Bastion.html#method.children
+/// [`Bastion::children`]: crate::Bastion::children
+/// [`with_strategy`]: Self::with_strategy
 pub struct Supervisor {
     bcast: Broadcast,
     // The order in which children and supervisors were added.
@@ -140,7 +138,7 @@ enum ActorSearchMethod {
 /// A "reference" to a [`Supervisor`], allowing to
 /// communicate with it.
 ///
-/// [`Supervisor`]: supervisor/struct.Supervisor.html
+// [`Supervisor`]: supervisor/struct.Supervisor.html
 pub struct SupervisorRef {
     id: BastionId,
     sender: Sender,
@@ -200,8 +198,8 @@ pub enum RestartPolicy {
 /// restoring failed actors. It it fails after N attempts,
 /// the supervisor will remove an actor.
 ///
-/// The default strategy used is `ActorRestartStrategy::Immediate`
-/// with the `RestartPolicy::Always` restart policy.
+/// The default strategy used is [`ActorRestartStrategy::Immediate`]
+/// with the [`RestartPolicy::Always`] restart policy.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RestartStrategy {
     restart_policy: RestartPolicy,
@@ -212,7 +210,9 @@ pub struct RestartStrategy {
 /// The strategy for restating an actor as far as it
 /// returned an failure.
 ///
-/// The default strategy is `Immediate`.
+/// The default strategy is [`Immediate`].
+///
+/// [`Immediate`]: ActorRestartStrategy::Immediate
 pub enum ActorRestartStrategy {
     /// Restart an actor as soon as possible, since the moment
     /// the actor finished with a failure.
@@ -468,8 +468,7 @@ impl Supervisor {
     /// # }
     /// ```
     ///
-    /// [`SupervisorRef`]: ../struct.SupervisorRef.html
-    /// [`supervisor_ref`]: #method.supervisor_ref
+    /// [`supervisor_ref`]: Self::supervisor_ref
     pub fn supervisor<S>(self, init: S) -> Self
     where
         S: FnOnce(Supervisor) -> Supervisor,
@@ -545,8 +544,7 @@ impl Supervisor {
     /// # }
     /// ```
     ///
-    /// [`SupervisorRef`]: ../struct.SupervisorRef.html
-    /// [`supervisor`]: #method.supervisor
+    /// [`supervisor`]: Self::supervisor
     pub fn supervisor_ref<S>(&mut self, init: S) -> SupervisorRef
     where
         S: FnOnce(Supervisor) -> Supervisor,
@@ -630,9 +628,9 @@ impl Supervisor {
     /// # }
     /// ```
     ///
-    /// [`Children`]: children/struct.Children.html
-    /// [`ChildrenRef`]: children/struct.ChildrenRef.html
-    /// [`children_ref`]: #method.children_ref
+    // [`Children`]: children/struct.Children.html
+    // [`ChildrenRef`]: children/struct.ChildrenRef.html
+    /// [`children_ref`]: Self::children_ref
     pub fn children<C>(self, init: C) -> Self
     where
         C: FnOnce(Children) -> Children,
@@ -721,9 +719,7 @@ impl Supervisor {
     /// # }
     /// ```
     ///
-    /// [`Children`]: children/struct.Children.html
-    /// [`ChildrenRef`]: children/struct.ChildrenRef.html
-    /// [`children`]: #method.children
+    /// [`children`]: Self::children
     pub fn children_ref<C>(&self, init: C) -> ChildrenRef
     where
         C: FnOnce(Children) -> Children,
@@ -810,10 +806,6 @@ impl Supervisor {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`SupervisionStrategy::OneForOne`]: supervisor/enum.SupervisionStrategy.html#variant.OneForOne
-    /// [`SupervisionStrategy::OneForAll`]: supervisor/enum.SupervisionStrategy.html#variant.OneForAll
-    /// [`SupervisionStrategy::RestForOne`]: supervisor/enum.SupervisionStrategy.html#variant.RestForOne
     pub fn with_strategy(mut self, strategy: SupervisionStrategy) -> Self {
         trace!(
             "Supervisor({}): Setting strategy: {:?}",
@@ -921,8 +913,6 @@ impl Supervisor {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`Callbacks`]: struct.Callbacks.html
     pub fn with_callbacks(mut self, callbacks: Callbacks) -> Self {
         trace!(
             "Supervisor({}): Setting callbacks: {:?}",
@@ -1591,8 +1581,6 @@ impl SupervisorRef {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`Supervisor`]: supervisor/struct.Supervisor.html
     pub fn supervisor<S>(&self, init: S) -> Result<Self, ()>
     where
         S: FnOnce(Supervisor) -> Supervisor,
@@ -1675,9 +1663,6 @@ impl SupervisorRef {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`Children`]: children/struct.Children.html
-    /// [`ChildrenRef`]: children/struct.ChildrenRef.html
     pub fn children<C>(&self, init: C) -> Result<ChildrenRef, ()>
     where
         C: FnOnce(Children) -> Children,
@@ -1775,10 +1760,6 @@ impl SupervisorRef {
     /// # Bastion::block_until_stopped();
     /// # }
     /// ```
-    ///
-    /// [`SupervisionStrategy::OneForOne`]: supervisor/enum.SupervisionStrategy.html#variant.OneForOne
-    /// [`SupervisionStrategy::OneForAll`]: supervisor/enum.SupervisionStrategy.html#variant.OneForAll
-    /// [`SupervisionStrategy::RestForOne`]: supervisor/enum.SupervisionStrategy.html#variant.RestForOne
     pub fn strategy(&self, strategy: SupervisionStrategy) -> Result<(), ()> {
         debug!(
             "SupervisorRef({}): Setting strategy: {:?}",
@@ -2051,11 +2032,11 @@ impl RestartStrategy {
     /// # Arguments
     ///
     /// * `restart_policy` - Defines a restart policy to use for failed actor:
-    ///     - [`RestartStrategy::Always`] would restart the
+    ///     - [`RestartPolicy::Always`] would restart the
     ///         failed actor each time as it fails.
-    ///     - [`RestartStrategy::Never`] would not restart the
+    ///     - [`RestartPolicy::Never`] would not restart the
     ///         failed actor and remove it from tracking.
-    ///     - [`RestartStrategy::Tries`] would restart the
+    ///     - [`RestartPolicy::Tries`] would restart the
     ///         failed actor a limited amount of times. If can't be started,
     ///         then will remove it from tracking.   
     ///
@@ -2079,13 +2060,6 @@ impl RestartStrategy {
     /// let restart_strategy = RestartStrategy::default()
     ///     .with_actor_restart_strategy(actor_restart_strategy);
     /// ```
-    ///
-    /// [`RestartStrategy::Always`]: enum.RestartPolicy.html#variant.Always
-    /// [`RestartStrategy::Never`]: enum.RestartPolicy.html#variant.Never
-    /// [`RestartStrategy::Tries`]: enum.RestartPolicy.html#variant.Tries
-    /// [`ActorRestartStrategy::Immediate`]: enum.ActorRestartStrategy.html#variant.Immediate
-    /// [`ActorRestartStrategy::LinearBackOff`]: enum.ActorRestartStrategy.html#variant.LinearBackOff
-    /// [`ActorRestartStrategy::ExponentialBackOff`]: enum.ActorRestartStrategy.html#variant.ExponentialBackOff
     pub fn new(restart_policy: RestartPolicy, strategy: ActorRestartStrategy) -> Self {
         RestartStrategy {
             restart_policy,


### PR DESCRIPTION
Transitioning to intra-doc-link will allow us to get better feedback about broken
links in the future. It also allows us to remove some annotations that are guessed
by rustdoc.

This PR *should* translate every link to intra-doc-link.

Fix #280.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bastion-rs/.github/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are passing with `cargo test`. 
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message is clear

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
