### PR TITLE
Export MessageHandler to the prelude

### DIFF
--- a/src/bastion/examples/fibonacci_message_handler.rs
+++ b/src/bastion/examples/fibonacci_message_handler.rs
@@ -1,4 +1,4 @@
-use bastion::{message::MessageHandler, prelude::*};
+use bastion::prelude::*;
 
 use tracing::{error, info};
 

--- a/src/bastion/examples/message_handler_multiple_types.rs
+++ b/src/bastion/examples/message_handler_multiple_types.rs
@@ -1,4 +1,3 @@
-use bastion::message::MessageHandler;
 use bastion::prelude::*;
 use std::fmt::Debug;
 use tracing::error;

--- a/src/bastion/src/lib.rs
+++ b/src/bastion/src/lib.rs
@@ -112,7 +112,7 @@ pub mod prelude {
     pub use crate::errors::*;
     #[cfg(not(target_os = "windows"))]
     pub use crate::io::*;
-    pub use crate::message::{Answer, AnswerSender, Message, Msg};
+    pub use crate::message::{Answer, AnswerSender, Message, MessageHandler, Msg};
     pub use crate::msg;
     pub use crate::path::{BastionPath, BastionPathElement};
     #[cfg(feature = "scaling")]


### PR DESCRIPTION
[Previous pull request][1] introduced the MessageHandler datatype, but did
not export it in the prelude.

[1]: https://github.com/bastion-rs/bastion/pull/309

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bastion-rs/.github/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are passing with `cargo test`. 
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message is clear

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
