### PR TITLE
proposal: distributor request fn

### DIFF
--- a/src/bastion/src/child.rs
+++ b/src/bastion/src/child.rs
@@ -283,6 +283,7 @@ impl Child {
             CallbackType::BeforeRestart => self.callbacks.before_restart(),
             CallbackType::AfterRestart => self.callbacks.after_restart(),
             CallbackType::AfterStop => self.callbacks.after_stop(),
+            CallbackType::AfterStart => self.callbacks.after_start(),
         }
     }
 
@@ -311,6 +312,8 @@ impl Child {
             error!("couldn't add actor to the distributors: {}", e);
             return;
         };
+
+        self.callbacks.after_start();
 
         loop {
             #[cfg(feature = "scaling")]

--- a/src/bastion/src/child.rs
+++ b/src/bastion/src/child.rs
@@ -416,7 +416,7 @@ impl Child {
             distributors
                 .iter()
                 .map(|&distributor| {
-                    global_dispatcher.register_recipient(distributor, child_ref.clone())
+                    global_dispatcher.register_recipient(&distributor, child_ref.clone())
                 })
                 .collect::<AnyResult<Vec<_>>>()?;
         }

--- a/src/bastion/src/children.rs
+++ b/src/bastion/src/children.rs
@@ -468,6 +468,8 @@ impl Children {
     /// ```
     /// [`RecipientHandler`]: crate::dispatcher::RecipientHandler
     pub fn with_distributor(mut self, distributor: Distributor) -> Self {
+        // Try to register the distributor as soon as we're aware of it
+        let _ = SYSTEM.dispatcher().register_distributor(&distributor);
         self.distributors.push(distributor);
         self
     }

--- a/src/bastion/src/children.rs
+++ b/src/bastion/src/children.rs
@@ -1159,6 +1159,16 @@ impl Children {
         Ok(())
     }
 
+    /// Registers all declared local distributors in the global dispatcher.
+    pub(crate) fn register_distributors(&self) -> AnyResult<()> {
+        let global_dispatcher = SYSTEM.dispatcher();
+
+        for distributor in self.distributors.iter() {
+            global_dispatcher.register_distributor(distributor)?;
+        }
+        Ok(())
+    }
+
     /// Removes all declared local distributors from the global dispatcher.
     pub(crate) fn remove_distributors(&self) -> AnyResult<()> {
         let global_dispatcher = SYSTEM.dispatcher();

--- a/src/bastion/src/context.rs
+++ b/src/bastion/src/context.rs
@@ -917,7 +917,7 @@ mod context_tests {
         let children =
         Bastion::children(|children| {
             children.with_exec(|ctx: BastionContext| async move {
-                msg! { ctx.try_recv_timeout(std::time::Duration::from_millis(1)).await.expect("recv_timeout failed"),
+                msg! { ctx.try_recv_timeout(std::time::Duration::from_millis(5)).await.expect("recv_timeout failed"),
                     ref msg: &'static str => {
                         assert_eq!(msg, &"test recv timeout");
                     };

--- a/src/bastion/src/context.rs
+++ b/src/bastion/src/context.rs
@@ -856,9 +856,6 @@ mod context_tests {
         test_try_recv_fail();
         test_try_recv_timeout();
         test_try_recv_timeout_fail();
-
-        Bastion::stop();
-        Bastion::block_until_stopped();
     }
 
     fn test_recv() {

--- a/src/bastion/src/context.rs
+++ b/src/bastion/src/context.rs
@@ -851,11 +851,11 @@ mod context_tests {
         Bastion::init();
         Bastion::start();
 
-        run_test(test_recv);
-        run_test(test_try_recv);
-        run_test(test_try_recv_fail);
-        run_test(test_try_recv_timeout);
-        run_test(test_try_recv_timeout_fail);
+        test_recv();
+        test_try_recv();
+        test_try_recv_fail();
+        test_try_recv_timeout();
+        test_try_recv_timeout_fail();
 
         Bastion::stop();
         Bastion::block_until_stopped();
@@ -949,15 +949,6 @@ mod context_tests {
         run!(async { Delay::new(std::time::Duration::from_millis(2)).await });
 
         // The child panicked, but we should still be able to send things to it
-        assert!(children.broadcast("test recv timeout").is_ok());
-    }
-
-    fn run_test<T>(test: T) -> ()
-    where
-        T: FnOnce() -> () + panic::UnwindSafe,
-    {
-        let result = panic::catch_unwind(|| test());
-
-        assert!(result.is_ok())
+        children.broadcast("test recv timeout").unwrap();
     }
 }

--- a/src/bastion/src/dispatcher.rs
+++ b/src/bastion/src/dispatcher.rs
@@ -3,8 +3,9 @@
 //! group of actors through the dispatchers that holds information about
 //! actors grouped together.
 use crate::{
-    child_ref::{ChildRef, SendError},
+    child_ref::ChildRef,
     message::{Answer, Message},
+    prelude::SendError,
 };
 use crate::{distributor::Distributor, envelope::SignedMessage};
 use anyhow::Result as AnyResult;

--- a/src/bastion/src/dispatcher.rs
+++ b/src/bastion/src/dispatcher.rs
@@ -10,11 +10,15 @@ use crate::{
 use crate::{distributor::Distributor, envelope::SignedMessage};
 use anyhow::Result as AnyResult;
 use lever::prelude::*;
-use std::fmt::{self, Debug};
 use std::hash::{Hash, Hasher};
+use std::sync::RwLock;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
+};
+use std::{
+    collections::HashMap,
+    fmt::{self, Debug},
 };
 use tracing::{debug, trace};
 
@@ -346,7 +350,8 @@ impl Into<DispatcherType> for String {
 pub(crate) struct GlobalDispatcher {
     /// Storage for all registered group of actors.
     pub dispatchers: LOTable<DispatcherType, Arc<Box<Dispatcher>>>,
-    pub distributors: LOTable<Distributor, Arc<Box<(dyn RecipientHandler)>>>,
+    // TODO: switch to LOTable once lever implements write optimized granularity
+    pub distributors: Arc<RwLock<HashMap<Distributor, Box<(dyn RecipientHandler)>>>>,
 }
 
 impl GlobalDispatcher {
@@ -354,7 +359,12 @@ impl GlobalDispatcher {
     pub(crate) fn new() -> Self {
         GlobalDispatcher {
             dispatchers: LOTable::new(),
-            distributors: LOTable::new(),
+            distributors: Arc::new(RwLock::new(HashMap::new()))
+            // TODO: switch to LOTable once lever implements write optimized granularity
+            // distributors: LOTableBuilder::new()
+                //.with_concurrency(TransactionConcurrency::Optimistic)
+                //.with_isolation(TransactionIsolation::Serializable)
+                //.build(),
         }
     }
 
@@ -496,6 +506,13 @@ impl GlobalDispatcher {
 
     fn next(&self, distributor: Distributor) -> Result<Option<ChildRef>, SendError> {
         self.distributors
+            .read()
+            .map_err(|error| {
+                SendError::Other(anyhow::anyhow!(
+                    "couldn't get read lock on distributors {:?}",
+                    error
+                ))
+            })?
             .get(&distributor)
             .map(|recipient| recipient.next())
             .ok_or_else(|| SendError::from(distributor))
@@ -503,6 +520,13 @@ impl GlobalDispatcher {
 
     fn all(&self, distributor: Distributor) -> Result<Vec<ChildRef>, SendError> {
         self.distributors
+            .read()
+            .map_err(|error| {
+                SendError::Other(anyhow::anyhow!(
+                    "couldn't get read lock on distributors {:?}",
+                    error
+                ))
+            })?
             .get(&distributor)
             .map(|recipient| recipient.all())
             .ok_or_else(|| SendError::from(distributor))
@@ -535,17 +559,22 @@ impl GlobalDispatcher {
     /// Appends the information about actor to the recipients.
     pub(crate) fn register_recipient(
         &self,
-        distributor: Distributor,
+        distributor: &Distributor,
         child_ref: ChildRef,
     ) -> AnyResult<()> {
-        if let Some(recipient) = self.distributors.get(&distributor) {
-            recipient.register(child_ref);
+        let mut distributors = self.distributors.write().map_err(|error| {
+            anyhow::anyhow!("couldn't get read lock on distributors {:?}", error)
+        })?;
+        if let Some(recipients) = distributors.get(&distributor) {
+            recipients.register(child_ref);
         } else {
-            let actors = DefaultRecipientHandler::default();
-            actors.register(child_ref);
-            self.distributors
-                .insert(distributor, Arc::new(Box::new(actors)))?;
-        }
+            let recipients = DefaultRecipientHandler::default();
+            recipients.register(child_ref);
+            distributors.insert(
+                distributor.clone(),
+                Box::new(recipients) as Box<(dyn RecipientHandler)>,
+            );
+        };
         Ok(())
     }
 
@@ -554,37 +583,42 @@ impl GlobalDispatcher {
         distributor_list: &[Distributor],
         child_ref: ChildRef,
     ) -> AnyResult<()> {
+        let distributors = self.distributors.write().map_err(|error| {
+            anyhow::anyhow!("couldn't get read lock on distributors {:?}", error)
+        })?;
         distributor_list.iter().for_each(|distributor| {
-            if let Some(recipient) = self.distributors.get(distributor) {
-                recipient.remove(&child_ref);
-            }
+            distributors
+                .get(&distributor)
+                .map(|recipients| recipients.remove(&child_ref));
         });
         Ok(())
     }
 
     /// Adds distributor to the global registry.
     pub(crate) fn register_distributor(&self, distributor: &Distributor) -> AnyResult<()> {
-        let is_registered = self.distributors.contains_key(distributor);
-
-        if is_registered {
+        let mut distributors = self.distributors.write().map_err(|error| {
+            anyhow::anyhow!("couldn't get read lock on distributors {:?}", error)
+        })?;
+        if distributors.contains_key(&distributor) {
             debug!(
                 "The distributor with the '{:?}' name already registered in the cluster.",
                 distributor
             );
-            return Ok(());
+        } else {
+            distributors.insert(
+                distributor.clone(),
+                Box::new(DefaultRecipientHandler::default()),
+            );
         }
-
-        let instance = distributor.clone();
-        self.distributors.insert(
-            instance,
-            Arc::new(Box::new(DefaultRecipientHandler::default())),
-        )?;
         Ok(())
     }
 
     /// Removes distributor from the global registry.
     pub(crate) fn remove_distributor(&self, distributor: &Distributor) -> AnyResult<()> {
-        self.distributors.remove(distributor)?;
+        let mut distributors = self.distributors.write().map_err(|error| {
+            anyhow::anyhow!("couldn't get read lock on distributors {:?}", error)
+        })?;
+        distributors.remove(distributor);
         Ok(())
     }
 }

--- a/src/bastion/src/dispatcher.rs
+++ b/src/bastion/src/dispatcher.rs
@@ -562,6 +562,26 @@ impl GlobalDispatcher {
         Ok(())
     }
 
+    /// Adds distributor to the global registry.
+    pub(crate) fn register_distributor(&self, distributor: &Distributor) -> AnyResult<()> {
+        let is_registered = self.distributors.contains_key(distributor);
+
+        if is_registered {
+            debug!(
+                "The distributor with the '{:?}' name already registered in the cluster.",
+                distributor
+            );
+            return Ok(());
+        }
+
+        let instance = distributor.clone();
+        self.distributors.insert(
+            instance,
+            Arc::new(Box::new(DefaultRecipientHandler::default())),
+        )?;
+        Ok(())
+    }
+
     /// Removes distributor from the global registry.
     pub(crate) fn remove_distributor(&self, distributor: &Distributor) -> AnyResult<()> {
         self.distributors.remove(distributor)?;

--- a/src/bastion/src/errors.rs
+++ b/src/bastion/src/errors.rs
@@ -4,7 +4,14 @@
 //! A ReceiveError may however be raised when calling try_recv() or try_recv_timeout()
 //! More errors may happen in the future.
 
+use crate::envelope::Envelope;
+use crate::message::Msg;
+use crate::system::STRING_INTERNER;
+use crate::{distributor::Distributor, message::BastionMessage};
+use futures::channel::mpsc::TrySendError;
+use std::fmt::Debug;
 use std::time::Duration;
+use thiserror::Error;
 
 #[derive(Debug)]
 /// These errors happen
@@ -17,4 +24,47 @@ pub enum ReceiveError {
     Timeout(Duration),
     /// Generic error. Not used yet
     Other,
+}
+
+#[derive(Error, Debug)]
+/// `SendError`s occur when a message couldn't be dispatched through a distributor
+pub enum SendError {
+    #[error("couldn't send message. Channel Disconnected.")]
+    /// Channel has been closed before we could send a message
+    Disconnected(Msg),
+    #[error("couldn't send message. Channel is Full.")]
+    /// Channel is full, can't send a message
+    Full(Msg),
+    #[error("couldn't send a message I should have not sent. {0}")]
+    /// This error is returned when we try to send a message
+    /// that is not a BastionMessage::Message variant
+    Other(anyhow::Error),
+    #[error("No available Distributor matching {0}")]
+    /// The distributor we're trying to dispatch messages to is not registered in the system
+    NoDistributor(String),
+    #[error("Distributor has 0 Recipients")]
+    /// The distributor we're trying to dispatch messages to has no recipients
+    EmptyRecipient,
+}
+
+impl From<TrySendError<Envelope>> for SendError {
+    fn from(tse: TrySendError<Envelope>) -> Self {
+        let is_disconnected = tse.is_disconnected();
+        match tse.into_inner().msg {
+            BastionMessage::Message(msg) => {
+                if is_disconnected {
+                    Self::Disconnected(msg)
+                } else {
+                    Self::Full(msg)
+                }
+            }
+            other => Self::Other(anyhow::anyhow!("{:?}", other)),
+        }
+    }
+}
+
+impl From<Distributor> for SendError {
+    fn from(distributor: Distributor) -> Self {
+        Self::NoDistributor(STRING_INTERNER.resolve(distributor.interned()).to_string())
+    }
 }

--- a/src/bastion/src/supervisor.rs
+++ b/src/bastion/src/supervisor.rs
@@ -647,10 +647,18 @@ impl Supervisor {
         let children = Children::new(bcast);
         let mut children = init(children);
         debug!("Children({}): Initialized.", children.id());
+
         // FIXME: children group elems launched without the group itself being launched
         if let Err(e) = children.register_dispatchers() {
             warn!("couldn't register all dispatchers into the registry: {}", e);
         };
+        if let Err(e) = children.register_distributors() {
+            warn!(
+                "couldn't register all distributors into the registry: {}",
+                e
+            );
+        };
+
         children.launch_elems();
 
         debug!(

--- a/src/bastion/tests/message_signatures.rs
+++ b/src/bastion/tests/message_signatures.rs
@@ -19,7 +19,7 @@ fn spawn_responders() -> ChildrenRef {
             msg! { ctx.recv().await?,
                 msg: &'static str =!> {
                     if msg == "Hello" {
-                            assert!(signature!().is_sender_identified(), false);
+                            assert!(signature!().is_sender_identified(), "sender is not identified");
                             answer!(ctx, "Goodbye").unwrap();
                     }
                 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bastion-rs/.github/blob/master/CONTRIBUTING.md
-->

Proposal: Distributor request fn.

as shown [here](https://gist.github.com/o0Ignition0o/2bbb59bf2fdc85c0ee97783b3c2115c6#file-main-rs-L42) making a whole request can sometimes be a bit convoluted. the `Distributor::request()` function aims to be syntactic sugar to wrap this.

```rust
let answer = probes
    .ask_one(url.clone())
    .expect("couldn't send message to probes");

// Handle a reply
MessageHandler::new(answer.await.expect("couldn't get an answer")).on_tell(
    |probe_result: ProbeRunStatus, _| {
        info!("probe is done: {:?}", probe_result);
    },
);
``` 
will then become

```rust
let probe_run_status: Result<ProbeRunStatus, SendError> = probes
        .request(url.clone())
        .await
        .expect("couldn't receive reply");
 info!("probe is done: {:?}", probe_result);
```

It uses a channel() behind the scene, as shown in the signature:

```rust
pub fn request<R: Message>(
    &self,
    question: impl Message
) -> Receiver<Result<R, SendError>>
```
Here's what the documentation looks like so far:

![image](https://user-images.githubusercontent.com/9465678/114246191-4ceff000-9992-11eb-94eb-5e1d000b8898.png)

there's also a request_sync variant which is backed by a mpsc::channel(), and can be called like this: 

```rust
let reply: Result<ProbeRunStatus, SendError> = distributor
   .request_sync(url.clone())
   .recv()
   .expect("couldn't receive reply");
 info!("probe is done: {:?}", probe_result);
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are passing with `cargo test`. 
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message is clear

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
