### PR TITLE
Don't remove a distributor from the global dispatcher if it has clients

### DIFF
--- a/src/bastion/examples/distributor.rs
+++ b/src/bastion/examples/distributor.rs
@@ -61,8 +61,6 @@
 ///!         // We create the function to exec when each children is called
 ///!         .with_exec(move |ctx: BastionContext| async move { /* ... */ })
 ///! ```
-
-
 /*
 * cargo.toml:
 *
@@ -74,7 +72,6 @@
 * tracing-subscriber = "0.2.17"
 *
 */
-
 use anyhow::{anyhow, Context, Result as AnyResult};
 use bastion::distributor::*;
 use bastion::prelude::*;


### PR DESCRIPTION
Because distributors are usable globally by name, it's possible (and
useful) for multiple groups of children to use the same distributor.
However, if one of the groups of children is then stopped as part of the
normal flow of an application, the distributor is removed from the
global dispatcher, and all senders receive an error on trying to send to
that distributor, even if it still has active recipients from other
groups of children.

This commit changes `remove_distributor` in the global dispatcher so
that it checks to see if it still has recipients and only removes the
distributor if there are no remaining recipients.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bastion-rs/.github/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are passing with `cargo test`. 
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message is clear

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
