### PR TITLE
Distributor: Add request_timeout function

### DIFF
--- a/src/bastion/src/distributor.rs
+++ b/src/bastion/src/distributor.rs
@@ -797,7 +797,7 @@ mod distributor_tests {
         assert_eq!(42, answer_sync);
 
         run!(async {
-            let timeout = Duration::from_millis(10);
+            let timeout = Duration::from_millis(100);
             let answer_timeout: u8 = test_distributor
                 .request_timeout(question.clone(), timeout)
                 .await


### PR DESCRIPTION
As discussed with Ignition, a request_timeout function can be usefull as a timeout-able alternative to the request fn.
It seems to work as is ("proven" by the tests), but I am open to suggestions of improvements or anything.
Thanks for your time.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bastion-rs/.github/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are passing with `cargo test`. 
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message is clear

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
