### PR TITLE
make set_for_current function unsafe

### DIFF
--- a/src/bastion-executor/benches/stats.rs
+++ b/src/bastion-executor/benches/stats.rs
@@ -10,7 +10,7 @@ fn stress_stats<S: SmpStats + Sync + Send>(stats: &'static S) {
     let mut handles = Vec::with_capacity(*core_count());
     for core in get_cores() {
         let handle = thread::spawn(move || {
-            placement::set_for_current(*core);
+            unsafe { placement::set_for_current(*core) };
             for i in 0..100 {
                 stats.store_load(core.id, 10);
                 if i % 3 == 0 {

--- a/src/bastion-executor/src/placement.rs
+++ b/src/bastion-executor/src/placement.rs
@@ -17,7 +17,7 @@ pub fn get_num_cores() -> Option<usize> {
 }
 ///
 /// Sets the current threads affinity
-pub fn set_for_current(core_id: CoreId) {
+pub unsafe fn set_for_current(core_id: CoreId) {
     tracing::trace!("Executor: placement: set affinity on core {}", core_id.id);
     set_for_current_helper(core_id);
 }
@@ -41,7 +41,7 @@ fn get_core_ids_helper() -> Option<Vec<CoreId>> {
 #[cfg(target_os = "linux")]
 #[inline]
 fn set_for_current_helper(core_id: CoreId) {
-    linux::set_for_current(core_id);
+    unsafe { linux::set_for_current(core_id) };
 }
 
 #[cfg(target_os = "linux")]
@@ -68,7 +68,7 @@ mod linux {
         }
     }
 
-    pub fn set_for_current(core_id: CoreId) {
+    pub unsafe fn set_for_current(core_id: CoreId) {
         // Turn `core_id` into a `libc::cpu_set_t` with only
         // one core active.
         let mut set = new_cpu_set();
@@ -141,7 +141,7 @@ mod linux {
 
             assert!(!ids.is_empty());
 
-            set_for_current(ids[0]);
+            unsafe { set_for_current(ids[0]) };
 
             // Ensure that the system pinned the current thread
             // to the specified core.
@@ -177,7 +177,7 @@ fn get_core_ids_helper() -> Option<Vec<CoreId>> {
 #[cfg(target_os = "windows")]
 #[inline]
 fn set_for_current_helper(core_id: CoreId) {
-    windows::set_for_current(core_id);
+    unsafe { windows::set_for_current(core_id);
 }
 
 #[cfg(target_os = "windows")]
@@ -211,7 +211,7 @@ mod windows {
         }
     }
 
-    pub fn set_for_current(core_id: CoreId) {
+    pub unsafe fn set_for_current(core_id: CoreId) {
         // Convert `CoreId` back into mask.
         let mask: DWORD_PTR = 1 << core_id.id;
 
@@ -267,7 +267,7 @@ mod windows {
 
             assert!(ids.len() > 0);
 
-            set_for_current(ids[0]);
+            unsafe { set_for_current(ids[0]) };
         }
     }
 }
@@ -283,7 +283,7 @@ fn get_core_ids_helper() -> Option<Vec<CoreId>> {
 #[cfg(target_os = "macos")]
 #[inline]
 fn set_for_current_helper(core_id: CoreId) {
-    macos::set_for_current(core_id);
+    unsafe { macos::set_for_current(core_id) };
 }
 
 #[cfg(target_os = "macos")]
@@ -328,7 +328,7 @@ mod macos {
         )
     }
 
-    pub fn set_for_current(core_id: CoreId) {
+    pub unsafe fn set_for_current(core_id: CoreId) {
         let thread_affinity_policy_count: MachMsgTypeNumberT =
             mem::size_of::<ThreadAffinityPolicyDataT>() as MachMsgTypeNumberT
                 / mem::size_of::<IntegerT>() as MachMsgTypeNumberT;
@@ -370,7 +370,7 @@ mod macos {
 
             assert!(ids.len() > 0);
 
-            set_for_current(ids[0]);
+            unsafe { set_for_current(ids[0]) };
         }
     }
 }
@@ -410,6 +410,6 @@ mod tests {
 
         assert!(!ids.is_empty());
 
-        set_for_current(ids[0]);
+        unsafe { set_for_current(ids[0]) };
     }
 }

--- a/src/bastion-executor/src/thread_manager.rs
+++ b/src/bastion-executor/src/thread_manager.rs
@@ -298,7 +298,7 @@ impl DynamicPoolManager {
     fn affinity_pinner() {
         if 1 != *load_balancer::core_count() {
             let mut core = ROUND_ROBIN_PIN.lock().unwrap();
-            placement::set_for_current(*core);
+            unsafe { placement::set_for_current(*core) };
             core.id = (core.id + 1) % *load_balancer::core_count();
         }
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bastion-rs/.github/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are passing with `cargo test`. 
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message is clear

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
https://github.com/bastion-rs/bastion/blob/c6016a95f64965e0b9ae61c18fdfbe3437eef65f/src/bastion-executor/src/placement.rs#L20-L23
https://github.com/bastion-rs/bastion/blob/c6016a95f64965e0b9ae61c18fdfbe3437eef65f/src/bastion-executor/src/placement.rs#L71-L86
https://github.com/bastion-rs/bastion/blob/c6016a95f64965e0b9ae61c18fdfbe3437eef65f/src/bastion-executor/src/placement.rs#L214-L222
**Target_OS = "windows"**
Hello, in some tests of your bastion_executor project, my program appeared "attempt to shift left with overflow", and the traceback indicated that the set_for_current function in this project crashed when doing a left shift operation.
```rust
extern crate bastion_executor;
use bastion_executor::placement::CoreId;
fn main() {
    let a:CoreId = CoreId { id: 771157545605903283 };
    let _ = bastion_executor::placement::set_for_current(a);
}
``` 
`thread 'main' panicked at 'attempt to shift left with overflow'`
`stack backtrace:
   0: std::panicking::begin_panic_handler  at /rustc/73c9eaf21454b718e7c549984d9eb6e1f75e995c/library\std\src\panicking.rs:575
   1: core::panicking::panic_fmt  at /rustc/73c9eaf21454b718e7c549984d9eb6e1f75e995c/library\core\src\panicking.rs:65
   2: core::panicking::panic  at /rustc/73c9eaf21454b718e7c549984d9eb6e1f75e995c/library\core\src\panicking.rs:115
   3: bastion_executor::placement::windows::set_for_current at C:\Users\.cargo\registry\src\github.com-1ecc6299db9ec823\bastion-executor-0.4.2\src\placement.rs:216
   4: bastion_executor::placement::set_for_current_helper at C:\Users\.cargo\registry\src\github.com-1ecc6299db9ec823\bastion-executor-0.4.2\src\placement.rs:180
   5: bastion_executor::placement::set_for_current at C:\Users\.cargo\registry\src\github.com-1ecc6299db9ec823\bastion-executor-0.4.2\src\placement.rs:22
   6: hello::main at .\src\main.rs:15
   7: core::ops::function::FnOnce::call_once<void (*)(),tuple$<> >  at /rustc/73c9eaf21454b718e7c549984d9eb6e1f75e995c\library\core\src\ops\function.rs:510
`
**Target_OS = "linux"**
`thread 'main' panicked at 'index out of bounds: the len is 16 but the index is 12049336650092238'
`
`stack backtrace:
   0: rust_begin_unwind  at /rustc/8a97b4812a7a46bb5206487c2455b9c5bfcbd1b9/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt  at /rustc/8a97b4812a7a46bb5206487c2455b9c5bfcbd1b9/library/core/src/panicking.rs:64:14
   2: core::panicking::panic_bounds_check  at /rustc/8a97b4812a7a46bb5206487c2455b9c5bfcbd1b9/library/core/src/panicking.rs:147:5
   3: libc::unix::linux_like::linux::CPU_SET  at /home/dl2/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.139/src/unix/linux_like/linux/mod.rs:3630:9
   4: bastion_executor::placement::linux::set_for_current at /home/dl2/.cargo/registry/src/github.com-1ecc6299db9ec823/bastion-executor-0.4.2/src/placement.rs:76:18
   5: bastion_executor::placement::set_for_current_helper  at /home/dl2/.cargo/registry/src/github.com-1ecc6299db9ec823/bastion-executor-0.4.2/src/placement.rs:44:5
   6: bastion_executor::placement::set_for_current at /home/dl2/.cargo/registry/src/github.com-1ecc6299db9ec823/bastion-executor-0.4.2/src/placement.rs:22:5
   7: hello_world::main at ./src/main.rs:17:13
   8: core::ops::function::FnOnce::call_once at /rustc/8a97b4812a7a46bb5206487c2455b9c5bfcbd1b9/library/core/src/ops/function.rs:507:5
`
I think it should be marked as unsafe to remind other callers of the real legal input parameters to avoid possible errors.
